### PR TITLE
BUG: fix relative path of test files

### DIFF
--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const NodeController = require('../worker/controller/NodeController');
 
 
@@ -6,12 +7,12 @@ var readline = require('readline');
 var program = require('commander');
 
 
-const B1Path = "/home/wildermind/WebstormProjects/enigma-p2p/test/testUtils/id-l";
+const B1Path = path.join(__dirname, "../../test/testUtils/id-l");
 const B1Port = "10300";
-const B2Path = "/home/wildermind/WebstormProjects/enigma-p2p/test/testUtils/id-d";
-const B2Port = "103001";
+const B2Path = path.join(__dirname, "../../test/testUtils/id-d");
+const B2Port = "10301";
 const B1Addr = '/ip4/0.0.0.0/tcp/10300/ipfs/QmcrQZ6RJdpYuGvZqD5QEHAv6qX4BrQLJLQPQUrTrzdcgm';
-const B2Addr = '/ip4/0.0.0.0/tcp/103001/ipfs/Qma3GsJmB47xYuyahPZPSadh1avvxfyYQwk8R3UnFrQ6aP';
+const B2Addr = '/ip4/0.0.0.0/tcp/10301/ipfs/Qma3GsJmB47xYuyahPZPSadh1avvxfyYQwk8R3UnFrQ6aP';
 
 let configObject = {
     'bootstrapNodes' : null,

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const parallel = require('async/parallel');
 const EnigmaNode = require('../src/worker/EnigmaNode');
 const quickBuilderUtils = require('./testUtils/quickBuilderUtil');
@@ -14,10 +15,11 @@ const TEST_TREE = require('./test_tree').TEST_TREE;
 const WorkerBuilder = require('../src/worker/builder/WorkerBuilder');
 const NodeController = require('../src/worker/controller/NodeController');
 
-const B1Path = "/home/wildermind/WebstormProjects/enigma-p2p/test/testUtils/id-l";
+const B1Path = path.join(__dirname,"testUtils/id-l");
 const B1Port = "10300";
-const B2Path = "/home/wildermind/WebstormProjects/enigma-p2p/test/testUtils/id-d";
-const B2Port = "103001";
+const B2Path = "../../test/testUtils/id-d";
+const B2Port = "10301";
+
 
 it('#1 Should test the worker builder', async function(){
     let tree = TEST_TREE['basic'];
@@ -55,7 +57,7 @@ it('#2 Should test handshake with 1 node', async function(){
     }
     return new Promise(async (resolve)=>{
         let bootstrapNodes = ["/ip4/0.0.0.0/tcp/10300/ipfs/QmcrQZ6RJdpYuGvZqD5QEHAv6qX4BrQLJLQPQUrTrzdcgm"];
-        let dnsController = NodeController.initDefaultTemplate({"port":B1Port, "idPath" : B1Path, "nickname":"dns","bootstrapNodes":bootstrapNodes});
+        let dnsController = NodeController.initDefaultTemplate({"port":B1Port, "idPath":B1Path, "nickname":"dns", "bootstrapNodes":bootstrapNodes});
         let peerController = NodeController.initDefaultTemplate({"nickname":"peer" , "bootstrapNodes":bootstrapNodes});
 
         await dnsController.engNode().syncRun();


### PR DESCRIPTION
Paths of testUtils configuration files were hardcoded to absolute paths in @Isan-Rivkin's machine. Made them relative so that scripts run in other machines :)