### PR TITLE
BUG: envelope obj was ignored. Fixed

### DIFF
--- a/src/core/actions/GetRegistrationParamsAction.js
+++ b/src/core/actions/GetRegistrationParamsAction.js
@@ -7,10 +7,7 @@ class GetRegistrationParamsAction{
     this._coreRuntime = coreRuntime;
   }
   execute(envelop){
-    let request = {
-      id : nodeUtils.randId(),
-      type : Msg.GetRegistrationParams
-    };
+    let request = envelop._obj;
     this._coreRuntime.execCmd(Msg.CORE_DB_ACTION,{
       envelop : envelop,
       sendMsg : request,

--- a/src/core/actions/NewTaskEncryptionKeyAction.js
+++ b/src/core/actions/NewTaskEncryptionKeyAction.js
@@ -7,10 +7,7 @@ class NewTaskEncryptionKeyAction{
     this._coreRuntime = coreRuntime;
   }
   execute(envelop){
-    let request = {
-      id : nodeUtils.randId(),
-      type : Msg.NewTaskEncryptionKey
-    };
+    let request = envelop._obj;
     this._coreRuntime.execCmd(Msg.CORE_DB_ACTION,{
       envelop : envelop,
       sendMsg : request,


### PR DESCRIPTION
Handling of the envelope object inside the CoreRuntime actions was improperly implemented because it did not use the envelope._obj at all, but instead recreated an envelope out of some standard parameters. Fixed it.

It is possible that some other actions implemented in `/src/core/actions` suffer from the same issue. For the time being only `GetRegistrationParamsAction` and `NewTaskEncryptionKeyAction` have been corrected. After the fix both files are identical, which questions the need for different templates for both actions instead of using a common one, FYI @Isan-Rivkin 