### PR TITLE
BLD: adj getNewEncryptionKeys to match specs, added UT

### DIFF
--- a/src/client_api/JsonRpcServer.js
+++ b/src/client_api/JsonRpcServer.js
@@ -5,76 +5,77 @@
  * */
 const EventEmitter = require('events').EventEmitter;
 const constants = require('../common/constants');
-const nodeUtils = require('../common/utils');
+// const nodeUtils = require('../common/utils');
 const jayson = require('jayson');
 const PROXY_FLAG = constants.MAIN_CONTROLLER_NOTIFICATIONS.Proxy;
 const Envelop = require('../main_controller/channels/Envelop');
-class QuoteAction{}
+// class QuoteAction {}
 
-class JsonRpcServer extends EventEmitter{
-  constructor(config){
+class JsonRpcServer extends EventEmitter {
+  constructor(config) {
     super();
     this._communicator = null;
     this._port = config.port;
     this._peerId = config.peerId;
     this._pendingSequence = {};
     this._server = jayson.server({
-      getInfo: (args,callback)=>{
-        console.log("getInfo request...");
-        callback(null,{peerId : this._peerId , status : "ok"});
+      getInfo: (args, callback)=>{
+        console.log('getInfo request...');
+        callback(null, {peerId: this._peerId, status: 'ok'});
       },
-      getWorkerEncryptionKey : (args,callback)=>{
-        if(args.length === 0){
-          //TODO:: do more stuff to validate input i.e check valid signing key
-          //TODO:: to reduce network calls
-          callback('no signing key');
-        }else{
-
-          let workerSignKey = args[0];
-          let envelop = new Envelop(true,
-            {
-              workerSignKey : workerSignKey,
-              sequence : nodeUtils.randId(),
-              request : 'getWorkerEncryptionKey',
-            },
-            PROXY_FLAG
+      getWorkerEncryptionKey: (args, callback)=>{
+        if (args.length !== 2) {
+          // TODO:: do more stuff to validate input i.e check valid signing key
+          // TODO:: to reduce network calls
+          callback({'code': -32602, 'message': 'Invalid params'});
+        } else {
+          const workerSignKey = args[0];
+          const userPubKey = args[1];
+          const envelop = new Envelop(true,
+              {
+                workerSignKey: workerSignKey,
+                userPubKey: userPubKey,
+                type: constants.CORE_REQUESTS.NewTaskEncryptionKey,
+              },
+              PROXY_FLAG
           );
 
           this.getCommunicator()
-          .sendAndReceive(envelop)
-          .then(resEnv=>{
-            let result = {};
-            result.targetWorkerKey = resEnv.content().result.senderKey;
-            result.workerEncryptionKey = resEnv.content().result.workerEncryptionKey;
-            result.workerSig = resEnv.content().result.workerSig;
-            result.msgId = resEnv.content().result.msgId;
-            callback(null, result);
-          });
+              .sendAndReceive(envelop)
+              .then((resEnv)=>{
+                console.log('GOT SOMETHING');
+                const result = {};
+                console.log(resEnv);
+                result.targetWorkerKey = resEnv.content().result.senderKey;
+                result.workerEncryptionKey = resEnv.content().result.workerEncryptionKey;
+                result.workerSig = resEnv.content().result.workerSig;
+                callback(null, result);
+              });
         }
-      }
+      },
     });
   }
-  listen(){
-    console.log("JsonRpcServer listening on port " + this._port);
+  listen() {
+    console.log('JsonRpcServer listening on port ' + this._port);
     this._server.http().listen(this._port);
   }
   /** MUST for runtime manager (main controller)*/
-  type(){
+  type() {
     return constants.RUNTIME_TYPE.JsonRpcApi;
   }
   /**
    * Returns the Channel commiunicator, used by Actions
    * @return {Communicator} this._communicator
    * */
-  getCommunicator(){
+  getCommunicator() {
     return this._communicator;
   }
   /** MUST for runtime manager (main controller)*/
-  setChannel(communicator){
+  setChannel(communicator) {
     this._communicator = communicator;
     this._communicator.setOnMessage((envelop)=>{
-      console.log("!!1!!!~!!#$%^&*(&^&%^$#$#$%^&*()");
-      console.log("@@@@@@@@@@@@@@@@@@@@@ ggot envelop @@@@@");
+      console.log('!!1!!!~!!#$%^&*(&^&%^$#$#$%^&*()');
+      console.log('@@@@@@@@@@@@@@@@@@@@@ ggot envelop @@@@@');
       // let concreteCmd = envelop.content().type;
       // let action = this._actions[concreteCmd];
       // if(action){

--- a/src/core/core_server_mock/core_server.js
+++ b/src/core/core_server_mock/core_server.js
@@ -1,7 +1,21 @@
 const zmq = require('zeromq');
 const constants = require('../../common/constants');
 const MsgTypes = constants.CORE_REQUESTS;
-const Quote = 'AgAAANoKAAAHAAYAAAAAABYB+Vw5ueowf+qruQGtw+54eaWW7MiyrIAooQw/uU3eBAT/////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAALcVy53ugrfvYImaDi1ZW5RueQiEekyu/HmLIKYvg6OxAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACD1xnnferKFHD2uvYqTXdDA8iZ22kCD5xw7h38CMfOngAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACGcCDM4cgbYe6zQSwWQINFsDvd21kXGeteDakovCXPDwjJ31WG0K+wyDDRo8PFi293DtIr6DgNqS/guQSkglPJqAIAALbvs91Ugh9/yhBpAyGQPth+UWXRboGkTaZ3DY8U+Upkb2NWbLPkXbcMbB7c3SAfV4ip/kPswyq0OuTTiJijsUyOBOV3hVLIWM4f2wVXwxiVRXrfeFs/CGla6rGdRQpFzi4wWtrdKisVK5+Cyrt2y38Ialm0NqY9FIjxlodD9D7TC8fv0Xog29V1HROlY+PvRNa+f2qp858w8j+9TshkvOAdE1oVzu0F8KylbXfsSXhH7d+n0c8fqSBoLLEjedoDBp3KSO0bof/uzX2lGQJkZhJ/RSPPvND/1gVj9q1lTM5ccbfVfkmwdN0B5iDA5fMJaRz5o8SVILr3uWoBiwx7qsUceyGX77tCn2gZxfiOICNrpy3vv384TO2ovkwvhq1Lg071eXAlxQVtPvRYOGgBAABydn7bEWdP2htRd46nBkGIAoNAnhMvbGNbGCKtNVQAU0N9f7CROLPOTrlw9gVlKK+G5vM1X95KTdcOjs8gKtTkgEos021zBs9R+whyUcs9npo1SJ8GzowVwTwWfVz9adw2jL95zwJ/qz+y5x/IONw9iXspczf7W+bwyQpNaetO9xapF6aHg2/1w7st9yJOd0OfCZsowikJ4JRhAMcmwj4tiHovLyo2fpP3SiNGzDfzrpD+PdvBpyQgg4aPuxqGW8z+4SGn+vwadsLr+kIB4z7jcLQgkMSAplrnczr0GQZJuIPLxfk9mp8oi5dF3+jqvT1d4CWhRwocrs7Vm1tAKxiOBzkUElNaVEoFCPmUYE7uZhfMqOAUsylj3Db1zx1F1d5rPHgRhybpNpxThVWWnuT89I0XLO0WoQeuCSRT0Y9em1lsozSu2wrDKF933GL7YL0TEeKw3qFTPKsmUNlWMIow0jfWrfds/Lasz4pbGA7XXjhylwum8e/I';
+const quote = 'AgAAANoKAAAHAAYAAAAAABYB+Vw5ueowf+qruQGtw+54eaWW7MiyrIAooQw/uU3eBAT/////AAAAAAAAAAAAAAAAAAAAAAAAAAAAA'+
+              'AAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAALcVy53ugrfvYImaDi1ZW5RueQiEekyu/HmLIKYvg6OxAAAAAAAAAA'+
+              'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACD1xnnferKFHD2uvYqTXdDA8iZ22kCD5xw7h38CMfOngAAAAAAAAAAAAAAAAAAAAAAAAA'+
+              'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'+
+              'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACGcCDM4cgbYe6zQ'+
+              'SwWQINFsDvd21kXGeteDakovCXPDwjJ31WG0K+wyDDRo8PFi293DtIr6DgNqS/guQSkglPJqAIAALbvs91Ugh9/yhBpAyGQPth+UW'+
+              'XRboGkTaZ3DY8U+Upkb2NWbLPkXbcMbB7c3SAfV4ip/kPswyq0OuTTiJijsUyOBOV3hVLIWM4f2wVXwxiVRXrfeFs/CGla6rGdRQp'+
+              'Fzi4wWtrdKisVK5+Cyrt2y38Ialm0NqY9FIjxlodD9D7TC8fv0Xog29V1HROlY+PvRNa+f2qp858w8j+9TshkvOAdE1oVzu0F8Kyl'+
+              'bXfsSXhH7d+n0c8fqSBoLLEjedoDBp3KSO0bof/uzX2lGQJkZhJ/RSPPvND/1gVj9q1lTM5ccbfVfkmwdN0B5iDA5fMJaRz5o8SVI'+
+              'Lr3uWoBiwx7qsUceyGX77tCn2gZxfiOICNrpy3vv384TO2ovkwvhq1Lg071eXAlxQVtPvRYOGgBAABydn7bEWdP2htRd46nBkGIAo'+
+              'NAnhMvbGNbGCKtNVQAU0N9f7CROLPOTrlw9gVlKK+G5vM1X95KTdcOjs8gKtTkgEos021zBs9R+whyUcs9npo1SJ8GzowVwTwWfVz'+
+              '9adw2jL95zwJ/qz+y5x/IONw9iXspczf7W+bwyQpNaetO9xapF6aHg2/1w7st9yJOd0OfCZsowikJ4JRhAMcmwj4tiHovLyo2fpP3'+
+              'SiNGzDfzrpD+PdvBpyQgg4aPuxqGW8z+4SGn+vwadsLr+kIB4z7jcLQgkMSAplrnczr0GQZJuIPLxfk9mp8oi5dF3+jqvT1d4CWhR'+
+              'wocrs7Vm1tAKxiOBzkUElNaVEoFCPmUYE7uZhfMqOAUsylj3Db1zx1F1d5rPHgRhybpNpxThVWWnuT89I0XLO0WoQeuCSRT0Y9em1'+
+              'lsozSu2wrDKF933GL7YL0TEeKw3qFTPKsmUNlWMIow0jfWrfds/Lasz4pbGA7XXjhylwum8e/I';
 const DbUtils = require('../../common/DbUtils');
 const DB_PROVIDER = require('./data/provider_db');
 const randomize = require('randomatic');
@@ -21,206 +35,223 @@ module.exports.runServer = (uri)=>{
   globalUri = uri;
   socket = zmq.socket('rep');
   socket.bindSync(uri);
-  console.log('Server mock on %s ' , uri);
+  console.log('Server mock on %s ', uri);
 
-  socket.on('message', msg=>{
+  socket.on('message', (msg)=>{
     msg = JSON.parse(msg);
-    console.log("[Mock Server] got msg! ", msg);
-    switch(msg.type){
+    console.log('[Mock Server] got msg! ', msg);
+    switch (msg.type) {
       case MsgTypes.GetRegistrationParams:
-        let response = getRegistrationParams(msg);
-        send(socket,response);
+        const response = getRegistrationParams(msg);
+        send(socket, response);
         break;
       case MsgTypes.GetAllTips:
-        let tips = getAllTips(msg);
+        const tips = getAllTips(msg);
         send(socket, tips);
         break;
       case MsgTypes.GetAllAddrs:
-        let addrs = getAllAddrs(msg);
+        const addrs = getAllAddrs(msg);
         send(socket, addrs);
         break;
       case MsgTypes.GetDeltas:
-        let deltas = getDeltas(msg);
-        send(socket,deltas);
+        const deltas = getDeltas(msg);
+        send(socket, deltas);
         break;
       case MsgTypes.GetContract:
-        let contract = getContract(msg);
-        send(socket,contract);
+        const contract = getContract(msg);
+        send(socket, contract);
         break;
       case MsgTypes.UpdateNewContract:
       case MsgTypes.UpdateDeltas:
         send(socket, {
-          type : msg.type,
-          id : msg.id,
-          success : true
+          type: msg.type,
+          id: msg.id,
+          success: true,
         });
         break;
       case MsgTypes.NewTaskEncryptionKey:
-        let encKeyMsg = getNewTaskEncryptionKey(msg);
-        send(socket,encKeyMsg);
+        const encKeyMsg = getNewTaskEncryptionKey(msg);
+        send(socket, encKeyMsg);
         break;
     }
   });
-
 };
 
 
-function send(socket,msg){
-  let error = {"error" : "from server error"};
-  if(msg){
+function send(socket, msg) {
+  const error = {'error': 'from server error'};
+  if (msg) {
     socket.send(JSON.stringify(msg));
-  }else{
+  } else {
     socket.send(JSON.stringify(error));
   }
 }
 
 
-function getNewTaskEncryptionKey(msg){
-  if(signKey === null){
-    signKey = randomize('Aa0',40 );
+function getNewTaskEncryptionKey(msg) {
+  if (signKey === null) {
+    signKey = randomize('Aa0', 40 );
   }
-  return{
-    id : msg.id,
-    type : msg.type,
-    senderKey : signKey,
-    msgId : randomize('Aa0',12),
-    workerEncryptionKey : '0061d93b5412c0c99c3c7867db13c4e13e51292bd52565d002ecf845bb0cfd8adfa5459173364ea8aff3fe24054cca88581f6c3c5e928097b9d4d47fce12ae47',
-    workerSig : 'worker-signature-with-signed-by-the-private-key-of-the-sender-key'
+  return {
+    id: msg.id,
+    type: msg.type,
+    userPubKey: signKey,
+    msgId: randomize('Aa0', 12),
+    result: {
+      workerEncryptionKey: '0061d93b5412c0c99c3c7867db13c4e13e51292bd52565d002ecf845bb0cfd8adfa5459173364ea8aff3fe2'+
+                           '4054cca88581f6c3c5e928097b9d4d47fce12ae47',
+      workerSig: 'worker-signature-with-signed-by-the-private-key-of-the-sender-key',
+    },
   };
 }
 
 
-function getContract(msg){
+function getContract(msg) {
   let bcode = null;
   let contractAddr = null;
-  DB_PROVIDER.forEach(entry=>{
-    if(msg.input[0] === DbUtils.toHexString(entry.address) && entry.key === -1){
+  DB_PROVIDER.forEach((entry)=>{
+    if (msg.input[0] === DbUtils.toHexString(entry.address) && entry.key === -1) {
       bcode = entry.delta;
       contractAddr = DbUtils.toHexString(entry.address);
     }
   });
   return {
-    type : msg.type,
-    id : msg.id,
-    address : contractAddr,
-    bytecode : bcode
-  }
+    type: msg.type,
+    id: msg.id,
+    address: contractAddr,
+    bytecode: bcode,
+  };
 }
 
-//input = [{address, from:key,to:key},...]
-//response deltas : [{address,key,data},...]
-function getDeltas(msg){
-  let response = [];
-  let input = msg.input;
-  let reqAddrs = input.map(r=>{
+// input = [{address, from:key,to:key},...]
+// response deltas : [{address,key,data},...]
+function getDeltas(msg) {
+  const response = [];
+  const input = msg.input;
+  const reqAddrs = input.map((r)=>{
     return r.address;
   });
-  let inputMap = {};
-  input.forEach(r=>{
+  const inputMap = {};
+  input.forEach((r)=>{
     inputMap[r.address] = r;
   });
-  DB_PROVIDER.forEach(entry=>{
-    let dbAddr = DbUtils.toHexString(entry.address);
-    let dbIndex = entry.key;
-    if(inputMap[dbAddr]){
-      let from = inputMap[dbAddr].from;
-      let to = inputMap[dbAddr].to;
-      if(dbIndex >= from && dbIndex <= to){
+  DB_PROVIDER.forEach((entry)=>{
+    const dbAddr = DbUtils.toHexString(entry.address);
+    const dbIndex = entry.key;
+    if (inputMap[dbAddr]) {
+      const from = inputMap[dbAddr].from;
+      const to = inputMap[dbAddr].to;
+      if (dbIndex >= from && dbIndex <= to) {
         response.push({
-          address : dbAddr,
-          key : dbIndex,
-          data : entry.delta,
+          address: dbAddr,
+          key: dbIndex,
+          data: entry.delta,
         });
       }
     }
   });
   return {
-    type : msg.type,
-    id : msg.id,
-    deltas : response
-  }
+    type: msg.type,
+    id: msg.id,
+    deltas: response,
+  };
 }
 
 
-function getAllAddrs(msg){
+function getAllAddrs(msg) {
   let addresses;
-  if(isProvider){
-    addresses = DB_PROVIDER.map(o=>{
-      if(o.key < 0){
+  if (isProvider) {
+    addresses = DB_PROVIDER.map((o)=>{
+      if (o.key < 0) {
         return DbUtils.toHexString(o.address);
-      }else{
+      } else {
         return [];
       }
-    }).filter(o=>{
+    }).filter((o)=>{
       return o.length > 0;
     });
-  }else{
-    addresses = TIPS.map(tip=>{
+  } else {
+    addresses = TIPS.map((tip)=>{
       return DbUtils.toHexString(tip.address);
     });
   }
   return {
-    type : msg.type,
-    id : msg.id,
+    type: msg.type,
+    id: msg.id,
     result: {
-      addresses : addresses,
+      addresses: addresses,
     },
-  }
+  };
 }
-function getAllTips(msg){
+function getAllTips(msg) {
   return {
-    type : msg.type,
-    id : msg.id,
-    tips : TIPS
-  }
+    type: msg.type,
+    id: msg.id,
+    tips: TIPS,
+  };
 }
 function getRegistrationParams(msg) {
-  if(signKey === null){
-    signKey = randomize('Aa0',40 );
+  if (signKey === null) {
+    signKey = '0x' + randomize('?0', 40, {chars: 'abcdef'});
   }
   return {
     type: msg.type,
     id: msg.id,
-    signingKey: signKey,
-    quote: Quote
-  }
+    result: {
+      signingKey: signKey,
+      quote: quote,
+    },
+  };
 }
 const TIPS = [{
-  address : [92,214,171,4,67,94,118,195,84,97,103,199,97,21,226,55,220,143,212,246,174,203,51,171,28,30,63,158,131,79,181,127],
-  key : 10,
-  delta : [171,255,84,134,4,62,190,60,15,43,249,32,21,188,170,27,22,23,8,248,158,176,219,85,175,190,54,199,198,228,198,87,124,33,158,115,60,173,162,16,
-    150,13,149,77,159,158,13,213,171,154,224,241,4,42,38,120,66,253,127,201,113,252,246,177,218,155,249,166,68,65,231,208,210,116,89,100,
-    207,92,200,194,48,70,71,210,240,15,213,37,16,235,133,77,158,220,171,214,256,22,229,31,
-    56,90,104,16,241,108,14,126,116,91,106,10,141,122,78,214,148,194,14,31,96,142,178,96,150,52,142,138,37,209,110,
-    153,185,96,236,44,46,192,138,108,168,91,145,153,60,88,7,229,183,174,187,204,233,54,89,107,16,237,247,66,76,39,
-    82,253,160,2,1,133,210,135,94,144,211,23,61,150,36,31,55,178,42,128,60,194,192,182,190,227,136,133,252,128,213,
-    88,135,204,213,199,50,191,7,61,104,87,210,127,76,163,11,175,114,207,167,26,249,222,222,73,175,207,222,86,42,236,92,194,214,
-    28,195,236,122,122,77,134,55,41,209,106,172,10,130,139,149,39,196,181,187,55,166,237,215,135,98,90,12,6,72,240,138,112,99,76,55,22,
-    231,223,153,119,15,98,26,77,139,89,64,24,108,137,118,38,142,19,131,220,252,248,212,120,231,26,21,228,246,179,104,207,76,218,144,
-    90,20,76,41,98,111,25,84,7,71,84,27,124,190,86,16,136,16,198,76,215,164,228,117,182,238,213,52,253,105,152,215,197,95,244,65,186,140,45,167,114,24,139,199,179,116,105,181],
-},{
-  address : [11,214,171,4,67,23,118,195,84,34,103,199,97,21,226,55,220,143,212,246,174,203,51,171,28,30,63,158,131,64,181,200],
-  key : 34,
-  delta : [11,255,84,134,4,62,190,60,15,43,249,32,21,188,170,27,22,23,8,248,158,176,219,85,175,190,54,199,198,228,198,87,124,33,158,115,60,173,162,16,
-    150,13,149,77,159,158,13,213,171,154,224,241,4,42,38,120,66,253,127,201,113,252,246,177,218,155,249,166,68,65,231,208,210,116,89,100,
-    207,92,200,194,48,70,123,210,240,15,213,37,16,235,133,77,158,220,171,33,256,22,229,31,
-    56,90,104,16,241,108,14,126,116,91,106,10,141,122,78,214,148,194,14,31,96,142,178,96,150,52,142,138,37,209,110,
-    153,185,96,236,44,46,192,138,108,168,91,145,153,60,88,7,229,183,174,187,204,233,54,89,107,16,237,247,66,76,39,
-    82,253,160,2,1,133,12,135,94,144,211,23,61,150,36,31,55,178,42,128,60,194,192,182,190,227,136,133,252,128,213,
-    88,135,204,213,199,50,191,7,61,104,87,210,127,76,163,11,175,114,207,167,26,249,222,222,73,175,207,222,86,42,236,92,194,214,
-    28,195,236,122,122,12,134,55,41,209,106,172,10,130,139,149,39,196,181,187,55,166,237,215,135,98,90,12,6,72,240,138,112,99,76,55,22,
-    231,223,153,119,15,98,26,77,139,89,64,24,108,137,118,38,142,19,131,220,252,248,212,120,231,26,21,228,246,179,104,207,76,218,144,
-    141,221,46,22,81,13,87,209,68,197,189,10,130,182,34,16,198,180,
-    90,20,76,41,98,111,25,84,7,71,84,27,124,190,86,16,136,16,198,76,215,164,228,117,182,238,213,52,253,105,152,215,197,95,244,65,186,140,45,167,114],
+  address: [92, 214, 171, 4, 67, 94, 118, 195, 84, 97, 103, 199, 97, 21, 226, 55, 220, 143, 212, 246, 174, 203, 51, 171,
+    28, 30, 63, 158, 131, 79, 181, 127],
+  key: 10,
+  delta: [171, 255, 84, 134, 4, 62, 190, 60, 15, 43, 249, 32, 21, 188, 170, 27, 22, 23, 8, 248, 158, 176, 219, 85, 175,
+    190, 54, 199, 198, 228, 198, 87, 124, 33, 158, 115, 60, 173, 162, 16, 150, 13, 149, 77, 159, 158, 13, 213, 171, 154,
+    224, 241, 4, 42, 38, 120, 66, 253, 127, 201, 113, 252, 246, 177, 218, 155, 249, 166, 68, 65, 231, 208, 210, 116, 89,
+    100, 207, 92, 200, 194, 48, 70, 71, 210, 240, 15, 213, 37, 16, 235, 133, 77, 158, 220, 171, 214, 256, 22, 229, 31,
+    56, 90, 104, 16, 241, 108, 14, 126, 116, 91, 106, 10, 141, 122, 78, 214, 148, 194, 14, 31, 96, 142, 178, 96, 150,
+    52, 142, 138, 37, 209, 110, 153, 185, 96, 236, 44, 46, 192, 138, 108, 168, 91, 145, 153, 60, 88, 7, 229, 183, 174,
+    187, 204, 233, 54, 89, 107, 16, 237, 247, 66, 76, 39, 82, 253, 160, 2, 1, 133, 210, 135, 94, 144, 211, 23, 61, 150,
+    36, 31, 55, 178, 42, 128, 60, 194, 192, 182, 190, 227, 136, 133, 252, 128, 213, 88, 135, 204, 213, 199, 50, 191, 7,
+    61, 104, 87, 210, 127, 76, 163, 11, 175, 114, 207, 167, 26, 249, 222, 222, 73, 175, 207, 222, 86, 42, 236, 92, 194,
+    214, 28, 195, 236, 122, 122, 77, 134, 55, 41, 209, 106, 172, 10, 130, 139, 149, 39, 196, 181, 187, 55, 166, 237,
+    215, 135, 98, 90, 12, 6, 72, 240, 138, 112, 99, 76, 55, 22, 231, 223, 153, 119, 15, 98, 26, 77, 139, 89, 64, 24,
+    108, 137, 118, 38, 142, 19, 131, 220, 252, 248, 212, 120, 231, 26, 21, 228, 246, 179, 104, 207, 76, 218, 144, 90,
+    20, 76, 41, 98, 111, 25, 84, 7, 71, 84, 27, 124, 190, 86, 16, 136, 16, 198, 76, 215, 164, 228, 117, 182, 238, 213,
+    52, 253, 105, 152, 215, 197, 95, 244, 65, 186, 140, 45, 167, 114, 24, 139, 199, 179, 116, 105, 181],
+}, {
+  address: [11, 214, 171, 4, 67, 23, 118, 195, 84, 34, 103, 199, 97, 21, 226, 55, 220, 143, 212, 246, 174, 203, 51, 171,
+    28, 30, 63, 158, 131, 64, 181, 200],
+  key: 34,
+  delta: [11, 255, 84, 134, 4, 62, 190, 60, 15, 43, 249, 32, 21, 188, 170, 27, 22, 23, 8, 248, 158, 176, 219, 85, 175,
+    190, 54, 199, 198, 228, 198, 87, 124, 33, 158, 115, 60, 173, 162, 16, 150, 13, 149, 77, 159, 158, 13, 213, 171, 154,
+    224, 241, 4, 42, 38, 120, 66, 253, 127, 201, 113, 252, 246, 177, 218, 155, 249, 166, 68, 65, 231, 208, 210, 116, 89,
+    100, 207, 92, 200, 194, 48, 70, 123, 210, 240, 15, 213, 37, 16, 235, 133, 77, 158, 220, 171, 33, 256, 22, 229, 31,
+    56, 90, 104, 16, 241, 108, 14, 126, 116, 91, 106, 10, 141, 122, 78, 214, 148, 194, 14, 31, 96, 142, 178, 96, 150,
+    52, 142, 138, 37, 209, 110, 153, 185, 96, 236, 44, 46, 192, 138, 108, 168, 91, 145, 153, 60, 88, 7, 229, 183, 174,
+    187, 204, 233, 54, 89, 107, 16, 237, 247, 66, 76, 39, 82, 253, 160, 2, 1, 133, 12, 135, 94, 144, 211, 23, 61, 150,
+    36, 31, 55, 178, 42, 128, 60, 194, 192, 182, 190, 227, 136, 133, 252, 128, 213, 88, 135, 204, 213, 199, 50, 191, 7,
+    61, 104, 87, 210, 127, 76, 163, 11, 175, 114, 207, 167, 26, 249, 222, 222, 73, 175, 207, 222, 86, 42, 236, 92, 194,
+    214, 28, 195, 236, 122, 122, 12, 134, 55, 41, 209, 106, 172, 10, 130, 139, 149, 39, 196, 181, 187, 55, 166, 237,
+    215, 135, 98, 90, 12, 6, 72, 240, 138, 112, 99, 76, 55, 22, 231, 223, 153, 119, 15, 98, 26, 77, 139, 89, 64, 24,
+    108, 137, 118, 38, 142, 19, 131, 220, 252, 248, 212, 120, 231, 26, 21, 228, 246, 179, 104, 207, 76, 218, 144, 141,
+    221, 46, 22, 81, 13, 87, 209, 68, 197, 189, 10, 130, 182, 34, 16, 198, 180, 90, 20, 76, 41, 98, 111, 25, 84, 7, 71,
+    84, 27, 124, 190, 86, 16, 136, 16, 198, 76, 215, 164, 228, 117, 182, 238, 213, 52, 253, 105, 152, 215, 197, 95, 244,
+    65, 186, 140, 45, 167, 114],
 },
-  {
-    address : [76,214,171,4,67,23,118,195,84,56,103,199,97,21,226,55,220,54,212,246,174,203,51,171,28,30,63,158,131,64,181,33],
-    key : 0,
-    delta : [150,13,149,77,159,158,13,213,171,154,224,241,4,42,38,120,66,253,127,201,113,252,246,177,218,155,249,166,68,65,231,208,210,116,89,100,
-      207,92,200,194,48,70,123,210,240,15,213,37,16,235,133,77,158,220,171,33,256,22,229,31,
-      82,253,160,2,1,133,12,135,94,144,211,23,61,150,36,31,55,178,42,128,60,194,192,182,190,227,136,133,252,128,213,
-      88,135,204,213,199,50,191,7,61,104,87,210,127,76,163,11,175,114,207,167,26,249,222,222,73,175,207,222,86,42,236,92,194,214,
-      28,195,236,122,122,12,134,55,41,209,106,172,10,130,139,149,39,196,181,187,55,166,237,215,135,98,90,12,6,72,240,138,112,99,76,55,22,
-      231,223,153,119,15,98,26,77,139,89,64,24,108,137,118,38,142,19,131,220,252,248,212,120,231,26,21,228,246,179,104,207,76,218,88],
-  }];
+{
+  address: [76, 214, 171, 4, 67, 23, 118, 195, 84, 56, 103, 199, 97, 21, 226, 55, 220, 54, 212, 246, 174, 203, 51, 171,
+    28, 30, 63, 158, 131, 64, 181, 33],
+  key: 0,
+  delta: [150, 13, 149, 77, 159, 158, 13, 213, 171, 154, 224, 241, 4, 42, 38, 120, 66, 253, 127, 201, 113, 252, 246,
+    177, 218, 155, 249, 166, 68, 65, 231, 208, 210, 116, 89, 100, 207, 92, 200, 194, 48, 70, 123, 210, 240, 15, 213, 37,
+    16, 235, 133, 77, 158, 220, 171, 33, 256, 22, 229, 31, 82, 253, 160, 2, 1, 133, 12, 135, 94, 144, 211, 23, 61, 150,
+    36, 31, 55, 178, 42, 128, 60, 194, 192, 182, 190, 227, 136, 133, 252, 128, 213, 88, 135, 204, 213, 199, 50, 191, 7,
+    61, 104, 87, 210, 127, 76, 163, 11, 175, 114, 207, 167, 26, 249, 222, 222, 73, 175, 207, 222, 86, 42, 236, 92, 194,
+    214, 28, 195, 236, 122, 122, 12, 134, 55, 41, 209, 106, 172, 10, 130, 139, 149, 39, 196, 181, 187, 55, 166, 237,
+    215, 135, 98, 90, 12, 6, 72, 240, 138, 112, 99, 76, 55, 22, 231, 223, 153, 119, 15, 98, 26, 77, 139, 89, 64, 24,
+    108, 137, 118, 38, 142, 19, 131, 220, 252, 248, 212, 120, 231, 26, 21, 228, 246, 179, 104, 207, 76, 218, 88],
+}];
 

--- a/src/main_controller/actions/ProxyAction.js
+++ b/src/main_controller/actions/ProxyAction.js
@@ -1,19 +1,19 @@
-const constatnts = require('../../common/constants');
+const constants = require('../../common/constants');
 
-class ProxyAction{
+class ProxyAction {
   constructor(controller) {
     this._controller = controller;
   }
   execute(reqCommunicator, envelop) {
-    //TODO:: go to db and get all tips
-    if(envelop.id()){
+    // TODO:: go to db and get all tips
+    if (envelop.id()) {
       // pass to core
-      this._controller.getCommunicator(constatnts.RUNTIME_TYPE.Node)
-      .thisCommunicator
-      .sendAndReceive(envelop)
-      .then(resEnv=>{
-        reqCommunicator.send(resEnv);
-      });
+      this._controller.getCommunicator(constants.RUNTIME_TYPE.Node)
+          .thisCommunicator
+          .sendAndReceive(envelop)
+          .then((resEnv)=>{
+            reqCommunicator.send(resEnv);
+          });
     }
   }
 }

--- a/src/worker/controller/actions/NewTaskEncryptionKeyAction.js
+++ b/src/worker/controller/actions/NewTaskEncryptionKeyAction.js
@@ -5,16 +5,15 @@ class NewTaskEncryptionKeyAction {
     this._controller = controller;
   }
   execute(params) {
-    let onResponse = params.onResponse;
-    let requestEnvelop = new Envelop(true,
-        {type : constants.CORE_REQUESTS.NewTaskEncryptionKey},
+    const onResponse = params.onResponse;
+    const requestEnvelop = new Envelop(params.request.id, params.request,
         constants.MAIN_CONTROLLER_NOTIFICATIONS.DbRequest);
 
     this._controller.communicator()
-    .sendAndReceive(requestEnvelop)
-    .then(responseEnvelop=>{
-      onResponse(null,responseEnvelop.content());
-    });
+        .sendAndReceive(requestEnvelop)
+        .then((responseEnvelop)=>{
+          onResponse(null, responseEnvelop.content());
+        });
   }
 }
 module.exports = NewTaskEncryptionKeyAction;

--- a/src/worker/controller/actions/SubscribeSelfSignKeyTopicPipelineAction.js
+++ b/src/worker/controller/actions/SubscribeSelfSignKeyTopicPipelineAction.js
@@ -7,55 +7,56 @@
 const constants = require('../../../common/constants');
 const waterfall = require('async/waterfall');
 
-class SubscribeSelfSignKeyTopicPipelineAction{
+class SubscribeSelfSignKeyTopicPipelineAction {
   constructor(controller) {
     this._controller = controller;
   }
   execute(params) {
     waterfall([
-        cb=>{
+      (cb)=>{
         // get registration params of the worker from core
-          this._controller.execCmd(constants.NODE_NOTIFICATIONS.REGISTRATION_PARAMS,
-          {
-                onResponse : (err,regParams)=>{
-                  cb(err,regParams);
-                }
-          });
+        this._controller.execCmd(constants.NODE_NOTIFICATIONS.REGISTRATION_PARAMS,
+            {
+              onResponse: (err, regParams)=>{
+                cb(err, regParams);
+              },
+            });
+      },
+    ], (err, regParams)=>{
+      if (err) {
+        this._controller.logger().error('[-] err in SubscribeSelfSignKeyTopicPipelineAction {%s}', err);
+        if (params.onResponse) {
+          return params.onResponse(err);
         }
-    ],(err,regParams)=>{
-      if(err){
-        this._controller.logger().error("[-] err in SubscribeSelfSignKeyTopicPipelineAction {%s}",err);
-        if(params.onResponse){return params.onResponse(err);}
       }
-
       // subscribe to topic
-      this._controller.execCmd(constants.NODE_NOTIFICATIONS.PUBSUB_SUB,{
-        topic : regParams.signingKey,
+      this._controller.execCmd(constants.NODE_NOTIFICATIONS.PUBSUB_SUB, {
+        topic: regParams.result.signingKey,
         // onPublish will be called everytime something is published to the topic param
         onPublish: (msg) =>{
-          let data = JSON.parse(msg.data);
-          let targetTopic = data.targetTopic;
-          this._controller.execCmd(constants.NODE_NOTIFICATIONS.NEW_TASK_INPUT_ENC_KEY,{
-            onResponse : (err,encKeyResult)=>{
-              this._controller.logger().debug("published msgId=[" + encKeyResult.msgId + "] encryption key");
-              this._controller.execCmd(constants.NODE_NOTIFICATIONS.PUBSUB_PUB,{
-                topic : targetTopic,
-                message : JSON.stringify({
-                  senderKey : regParams.signingKey,
-                  workerEncryptionKey : encKeyResult.workerEncryptionKey,
-                  workerSig : encKeyResult.workerSig,
-                  msgId : encKeyResult.msgId,
+          const data = JSON.parse(msg.data);
+          const request = data.request;
+          const targetTopic = data.targetTopic;
+          this._controller.execCmd(constants.NODE_NOTIFICATIONS.NEW_TASK_INPUT_ENC_KEY, {
+            request,
+            onResponse: (err, encKeyResult)=>{
+              this._controller.logger().debug('published msgId=[' + encKeyResult.msgId + '] encryption key');
+              this._controller.execCmd(constants.NODE_NOTIFICATIONS.PUBSUB_PUB, {
+                topic: targetTopic,
+                message: JSON.stringify({
+                  workerEncryptionKey: encKeyResult.result.workerEncryptionKey,
+                  workerSig: encKeyResult.result.workerSig,
                 }),
               });
             },
           });
         },
-        onSubscribed : ()=>{
-          this._controller.logger().debug('subscribed to [' + regParams.signingKey + '] self signKey');
-          if(params.onResponse){
+        onSubscribed: ()=>{
+          this._controller.logger().debug('subscribed to [' + regParams.result.signingKey + '] self signKey');
+          if (params.onResponse) {
             return params.onResponse(err);
           }
-        }
+        },
       });
     });
   }

--- a/src/worker/controller/actions/proxy/GetWorkerEncryptionKeyAction.js
+++ b/src/worker/controller/actions/proxy/GetWorkerEncryptionKeyAction.js
@@ -7,45 +7,45 @@
 const constants = require('../../../../common/constants');
 const Envelop = require('../../../../main_controller/channels/Envelop');
 
-class GetWorkerEncryptionKeyAction{
-  constructor(controller){
+class GetWorkerEncryptionKeyAction {
+  constructor(controller) {
     this._controller = controller;
   }
-  execute(requestEnvelop){
-    let workerSignKey = requestEnvelop.content().workerSignKey;
-    let sequence = requestEnvelop.content().sequence;
-    let selfId = this._controller.engNode().getSelfIdB58Str();
-    let targetTopic = selfId + workerSignKey + sequence;
-    let request = requestEnvelop.content().request;
+  execute(requestEnvelop) {
+    const workerSignKey = requestEnvelop.content().workerSignKey;
+    const sequence = requestEnvelop.content().id;
+    const selfId = this._controller.engNode().getSelfIdB58Str();
+    const targetTopic = selfId + workerSignKey + sequence;
+    const request = requestEnvelop.content();
     // subscribe to self topic parse response
     this._controller.execCmd(constants.NODE_NOTIFICATIONS.PUBSUB_SUB,
         {
-          topic : targetTopic,
-          onPublish : (msg)=>{
-            let result = {};
-            let data = JSON.parse(msg.data);
-            result.senderKey = data.senderKey;
+          topic: targetTopic,
+          onPublish: (msg)=>{
+            const result = {};
+            const data = JSON.parse(msg.data);
+            // result.senderKey = data.senderKey;
             result.workerEncryptionKey = data.workerEncryptionKey;
             result.workerSig = data.workerSig;
-            result.msgId = data.msgId;
-            let responseEnvelop = new Envelop(requestEnvelop.id(),{
-              result : result,
+            // result.msgId = data.msgId;
+            const responseEnvelop = new Envelop(requestEnvelop.id(), {
+              result: result,
             }, requestEnvelop.type());
             this._controller.communicator().send(responseEnvelop);
           },
-          onSubscribed : ()=>{
+          onSubscribed: ()=>{
             console.log('[rpc] temp subscribe to ' + targetTopic);
             // publish the actual request
-            this._controller.execCmd(constants.NODE_NOTIFICATIONS.PUBSUB_PUB,{
-              topic : workerSignKey,
-              message : JSON.stringify({
-                request : request,
-                sequence : sequence,
-                targetTopic : targetTopic,
+            this._controller.execCmd(constants.NODE_NOTIFICATIONS.PUBSUB_PUB, {
+              topic: workerSignKey,
+              message: JSON.stringify({
+                request: request,
+                sequence: sequence,
+                targetTopic: targetTopic,
               }),
             });
-          }
-    });
+          },
+        });
   }
 }
 module.exports = GetWorkerEncryptionKeyAction;

--- a/test/ipc_test.js
+++ b/test/ipc_test.js
@@ -1,6 +1,5 @@
 const TEST_TREE = require('./test_tree').TEST_TREE;
 const IpcClient = require('../src/core/ipc');
-const assert = require('assert');
 const waterfall = require('async/waterfall');
 const zmq = require('zeromq');
 const CoreRuntime = require('../src/core/CoreRuntime');
@@ -11,9 +10,9 @@ const constants = require('../src/common/constants');
 const nodeUtils = require('../src/common/utils');
 const EnvironmentBuilder = require('../src/main_controller/EnvironmentBuilder');
 
-it('#1 send acks to each other', async function(){
-  let tree = TEST_TREE['ipc'];
-  if(!tree['all'] || !tree['#1']){
+it('#1 send acks to each other', async function() {
+  const tree = TEST_TREE['ipc'];
+  if (!tree['all'] || !tree['#1']) {
     this.skip();
   }
 
@@ -21,78 +20,93 @@ it('#1 send acks to each other', async function(){
     const uri = 'tcp://127.0.0.1:5555';
     let serverSocket;
     let ipcClient;
-    let serverOk = false, clientOk = false;
+    let serverOk = false; let clientOk = false;
 
     waterfall([
       /** run the server - simulate core */
-      cb=>{
+      (cb)=>{
         serverSocket = zmq.socket('rep');
         serverSocket.bindSync(uri);
 
-        serverSocket.on('message', msg=>{
+        serverSocket.on('message', (msg)=>{
           serverOk = JSON.parse(msg).clientOk;
-          serverSocket.send(JSON.stringify({"serverOk":true}));
+          serverSocket.send(JSON.stringify({'serverOk': true}));
         });
         cb(null);
       },
       /** run the client */
-      cb=>{
+      (cb)=>{
         ipcClient = new IpcClient(uri);
         ipcClient.setResponseHandler((msg)=>{
-           clientOk = msg.serverOk;
-           cb(null);
+          clientOk = msg.serverOk;
+          cb(null);
         });
 
         ipcClient.connect();
-        ipcClient.sendJson({"clientOk":true});
-      }
-    ],(err)=>{
+        ipcClient.sendJson({'clientOk': true});
+      },
+    ], (err)=>{
       ipcClient.disconnect();
       serverSocket.disconnect(uri);
-        if(err){
-          assert.strictEqual(true,false,"error in waterfall");
-        }else{
-          assert.strictEqual(true, serverOk, "serverOk wrong");
-          assert.strictEqual(true, clientOk, "clientOk wrong");
-          resolve();
-        }
+      if (err) {
+        expect(err).toBeFalsy();
+      } else {
+        expect(serverOk).toBeTruthy();
+        expect(clientOk).toBeTruthy();
+        resolve();
+      }
     });
   });
 });
 
 it('#2 GetRegistrationParams - mock server', async function() {
-  let tree = TEST_TREE['ipc'];
+  const tree = TEST_TREE['ipc'];
   if (!tree['all'] || !tree['#2']) {
     this.skip();
   }
-  const Quote = 'AgAAANoKAAAHAAYAAAAAABYB+Vw5ueowf+qruQGtw+54eaWW7MiyrIAooQw/uU3eBAT/////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAALcVy53ugrfvYImaDi1ZW5RueQiEekyu/HmLIKYvg6OxAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACD1xnnferKFHD2uvYqTXdDA8iZ22kCD5xw7h38CMfOngAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACGcCDM4cgbYe6zQSwWQINFsDvd21kXGeteDakovCXPDwjJ31WG0K+wyDDRo8PFi293DtIr6DgNqS/guQSkglPJqAIAALbvs91Ugh9/yhBpAyGQPth+UWXRboGkTaZ3DY8U+Upkb2NWbLPkXbcMbB7c3SAfV4ip/kPswyq0OuTTiJijsUyOBOV3hVLIWM4f2wVXwxiVRXrfeFs/CGla6rGdRQpFzi4wWtrdKisVK5+Cyrt2y38Ialm0NqY9FIjxlodD9D7TC8fv0Xog29V1HROlY+PvRNa+f2qp858w8j+9TshkvOAdE1oVzu0F8KylbXfsSXhH7d+n0c8fqSBoLLEjedoDBp3KSO0bof/uzX2lGQJkZhJ/RSPPvND/1gVj9q1lTM5ccbfVfkmwdN0B5iDA5fMJaRz5o8SVILr3uWoBiwx7qsUceyGX77tCn2gZxfiOICNrpy3vv384TO2ovkwvhq1Lg071eXAlxQVtPvRYOGgBAABydn7bEWdP2htRd46nBkGIAoNAnhMvbGNbGCKtNVQAU0N9f7CROLPOTrlw9gVlKK+G5vM1X95KTdcOjs8gKtTkgEos021zBs9R+whyUcs9npo1SJ8GzowVwTwWfVz9adw2jL95zwJ/qz+y5x/IONw9iXspczf7W+bwyQpNaetO9xapF6aHg2/1w7st9yJOd0OfCZsowikJ4JRhAMcmwj4tiHovLyo2fpP3SiNGzDfzrpD+PdvBpyQgg4aPuxqGW8z+4SGn+vwadsLr+kIB4z7jcLQgkMSAplrnczr0GQZJuIPLxfk9mp8oi5dF3+jqvT1d4CWhRwocrs7Vm1tAKxiOBzkUElNaVEoFCPmUYE7uZhfMqOAUsylj3Db1zx1F1d5rPHgRhybpNpxThVWWnuT89I0XLO0WoQeuCSRT0Y9em1lsozSu2wrDKF933GL7YL0TEeKw3qFTPKsmUNlWMIow0jfWrfds/Lasz4pbGA7XXjhylwum8e/I';
-  const signingKey = '4910f5dce2e9C7395691344d8d2c71349B14F924';
-  return new Promise(async resolve => {
-    //start the server
+  const quote = 'AgAAANoKAAAHAAYAAAAAABYB+Vw5ueowf+qruQGtw+54eaWW7MiyrIAooQw/uU3eBAT/////AAAAAAAAAAAAAAAAAAAAAAAAAAAAA'+
+              'AAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAALcVy53ugrfvYImaDi1ZW5RueQiEekyu/HmLIKYvg6OxAAAAAAAAAA'+
+              'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACD1xnnferKFHD2uvYqTXdDA8iZ22kCD5xw7h38CMfOngAAAAAAAAAAAAAAAAAAAAAAAAA'+
+              'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'+
+              'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACGcCDM4cgbYe6zQ'+
+              'SwWQINFsDvd21kXGeteDakovCXPDwjJ31WG0K+wyDDRo8PFi293DtIr6DgNqS/guQSkglPJqAIAALbvs91Ugh9/yhBpAyGQPth+UW'+
+              'XRboGkTaZ3DY8U+Upkb2NWbLPkXbcMbB7c3SAfV4ip/kPswyq0OuTTiJijsUyOBOV3hVLIWM4f2wVXwxiVRXrfeFs/CGla6rGdRQp'+
+              'Fzi4wWtrdKisVK5+Cyrt2y38Ialm0NqY9FIjxlodD9D7TC8fv0Xog29V1HROlY+PvRNa+f2qp858w8j+9TshkvOAdE1oVzu0F8Kyl'+
+              'bXfsSXhH7d+n0c8fqSBoLLEjedoDBp3KSO0bof/uzX2lGQJkZhJ/RSPPvND/1gVj9q1lTM5ccbfVfkmwdN0B5iDA5fMJaRz5o8SVI'+
+              'Lr3uWoBiwx7qsUceyGX77tCn2gZxfiOICNrpy3vv384TO2ovkwvhq1Lg071eXAlxQVtPvRYOGgBAABydn7bEWdP2htRd46nBkGIAo'+
+              'NAnhMvbGNbGCKtNVQAU0N9f7CROLPOTrlw9gVlKK+G5vM1X95KTdcOjs8gKtTkgEos021zBs9R+whyUcs9npo1SJ8GzowVwTwWfVz'+
+              '9adw2jL95zwJ/qz+y5x/IONw9iXspczf7W+bwyQpNaetO9xapF6aHg2/1w7st9yJOd0OfCZsowikJ4JRhAMcmwj4tiHovLyo2fpP3'+
+              'SiNGzDfzrpD+PdvBpyQgg4aPuxqGW8z+4SGn+vwadsLr+kIB4z7jcLQgkMSAplrnczr0GQZJuIPLxfk9mp8oi5dF3+jqvT1d4CWhR'+
+              'wocrs7Vm1tAKxiOBzkUElNaVEoFCPmUYE7uZhfMqOAUsylj3Db1zx1F1d5rPHgRhybpNpxThVWWnuT89I0XLO0WoQeuCSRT0Y9em1'+
+              'lsozSu2wrDKF933GL7YL0TEeKw3qFTPKsmUNlWMIow0jfWrfds/Lasz4pbGA7XXjhylwum8e/I';
+  const signingKey = '0x4910f5dce2e9C7395691344d8d2c71349B14F924';
+  return new Promise(async (resolve) => {
+    // start the server
     const uri = 'tcp://127.0.0.1:5556';
     CoreServer.runServer(uri);
     await nodeUtils.sleep(1000);
-// start the client
-    let channels = Channel.biDirectChannel();
-    let c1 = channels.channel1;
-    let c2 = channels.channel2;
-    let coreRuntime = new CoreRuntime({uri : uri});
+    // start the client
+    const channels = Channel.biDirectChannel();
+    const c1 = channels.channel1;
+    const c2 = channels.channel2;
+    const coreRuntime = new CoreRuntime({uri: uri});
     coreRuntime.setChannel(c2);
     await nodeUtils.sleep(1000);
-    let reqEnv = new Envelop(true,{type : constants.CORE_REQUESTS.GetRegistrationParams}, constants.CORE_REQUESTS.GetRegistrationParams );
+    const reqEnv = new Envelop(true, {type: constants.CORE_REQUESTS.GetRegistrationParams},
+        constants.CORE_REQUESTS.GetRegistrationParams );
     c1.sendAndReceive(reqEnv)
-    .then(resEnv=>{
-      assert.strictEqual(Quote,resEnv.content().quote ,"quote don't match");
-      assert.strictEqual(signingKey.length, resEnv.content().signingKey.length, 'signing key dont match');
-      coreRuntime.disconnect();
-      CoreServer.disconnect();
-      resolve();
-    });
+        .then((resEnv)=>{
+          expect(resEnv.content().result.quote).toBe(quote);
+          expect(resEnv.content().result.signingKey.length).toBe(signingKey.length);
+          coreRuntime.disconnect();
+          CoreServer.disconnect();
+          resolve();
+        });
   });
 });
 
 it('#3 GetAllTips - mock server', async function() {
-  let tree = TEST_TREE['ipc'];
+  const tree = TEST_TREE['ipc'];
   if (!tree['all'] || !tree['#3']) {
     this.skip();
   }
@@ -102,25 +116,25 @@ it('#3 GetAllTips - mock server', async function() {
     'nickname': 'peer',
     'idPath': null,
   };
-  const uri = 'tcp://127.0.0.1:5454';
-  return new Promise(async resolve => {
+  const uri = 'tcp://127.0.0.1:5557';
+  return new Promise(async (resolve) => {
     // start the server (core)
     CoreServer.runServer(uri);
     await nodeUtils.sleep(1500);
     // start the client (enigma-p2p)
-    let builder = new EnvironmentBuilder();
-    let mainController = await builder
-    .setNodeConfig(peerConfig)
-    .setIpcConfig({uri : uri})
-    .build();
+    const builder = new EnvironmentBuilder();
+    const mainController = await builder
+        .setNodeConfig(peerConfig)
+        .setIpcConfig({uri: uri})
+        .build();
     await nodeUtils.sleep(2000);
-    let fromCache = false;
-    mainController.getNode().getAllLocalTips(fromCache,async (err,missingStates)=>{
-      assert.strictEqual(null,err,'some error in response [' + err + ' ]');
-      assert.strictEqual(3, missingStates.tips.length, 'len not 3');
-      assert.strictEqual(10, missingStates.tips[0].key, 'key not 10');
-      assert.strictEqual(34, missingStates.tips[1].key, 'key not 34');
-      assert.strictEqual(0, missingStates.tips[2].key, 'key not 0');
+    const fromCache = false;
+    mainController.getNode().getAllLocalTips(fromCache, async (err, missingStates)=>{
+      expect(err).toBeNull();
+      expect(missingStates.tips.length).toBe(3);
+      expect(missingStates.tips[0].key).toBe(10);
+      expect(missingStates.tips[1].key).toBe(34);
+      expect(missingStates.tips[2].key).toBe(0);
       await mainController.getNode().stop();
       mainController.getIpcClient().disconnect();
       CoreServer.disconnect();
@@ -128,3 +142,37 @@ it('#3 GetAllTips - mock server', async function() {
     });
   });
 }, 30000);
+
+it('#4 getNewTaskEncryptionKey - mock server', async function() {
+  const tree = TEST_TREE['ipc'];
+  if (!tree['all'] || !tree['#4']) {
+    this.skip();
+  }
+  const pubkey = '2ea8e4cefb78efd0725ed12b23b05079a0a433cc8a656f212accf58672fee44a20cfcaa50466237273e762e49ec912be613'+
+    '58d5e90bff56a53a0ed42abfe27e3';
+  return new Promise(async (resolve) => {
+    // start the server
+    const uri = 'tcp://127.0.0.1:5558';
+    CoreServer.runServer(uri);
+    await nodeUtils.sleep(1000);
+    // start the client
+    const channels = Channel.biDirectChannel();
+    const c1 = channels.channel1;
+    const c2 = channels.channel2;
+    const coreRuntime = new CoreRuntime({uri: uri});
+    coreRuntime.setChannel(c2);
+    await nodeUtils.sleep(1000);
+    const reqEnv = new Envelop(true, {type: constants.CORE_REQUESTS.NewTaskEncryptionKey, userPubKey: pubkey},
+        constants.CORE_REQUESTS.NewTaskEncryptionKey );
+    c1.sendAndReceive(reqEnv)
+        .then((resEnv)=>{
+          expect(resEnv.content().type).toBe(constants.CORE_REQUESTS.NewTaskEncryptionKey);
+          expect(resEnv.content().id).toBe(reqEnv._id);
+          expect(resEnv.content().result.workerEncryptionKey).toBeTruthy();
+          expect(resEnv.content().result.workerSig).toBeTruthy();
+          coreRuntime.disconnect();
+          CoreServer.disconnect();
+          resolve();
+        });
+  });
+});

--- a/test/test_tree.js
+++ b/test/test_tree.js
@@ -1,40 +1,41 @@
 module.exports.TEST_TREE = {
-  'basic' : {
-    'all' : true,
-    '#1' : true,
-    '#2' : true,
-    '#3' : true,
+  'basic': {
+    'all': true,
+    '#1': true,
+    '#2': true,
+    '#3': true,
   },
-  'ipc' :{
-    'all' : true,
-    '#1' : true,
-    '#2' : true,
-    '#3' : true,
+  'ipc': {
+    'all': true,
+    '#1': true,
+    '#2': true,
+    '#3': true,
+    '#4': true,
   },
-  'coverage' : {
-    'all' : true,
-    '#1' : true,
-    '#2' : true,
-    '#3' : true,
+  'coverage': {
+    'all': true,
+    '#1': true,
+    '#2': true,
+    '#3': true,
   },
-  'cache' :{
-    'all' : true,
-    '#1' : true
+  'cache': {
+    'all': true,
+    '#1': true,
   },
-  'ethereum' : {
-    'all' : true,
-    '#1' : true,
-    '#2' : true,
-    '#3' : true,
-    '#4' : true,
-    '#5' : true,
-    '#6' : true,
-    '#7' : true
+  'ethereum': {
+    'all': true,
+    '#1': true,
+    '#2': true,
+    '#3': true,
+    '#4': true,
+    '#5': true,
+    '#6': true,
+    '#7': true,
   },
-  'sync_basic' : {
-    'all' : true,
-    '#1' : true,
-  }
+  'sync_basic': {
+    'all': true,
+    '#1': true,
+  },
 };
 
 


### PR DESCRIPTION
Made several adjustments across the repository to account for the latest implementation of `NewTaskEncryptionKey` in core as specified [here](https://github.com/enigmampc/enigma-p2p/blob/elichai-patch-2/docs/IPC_MESSAGES.md#newtaskencryptionkey-message). 

- Adjusted the core-mock-server to match the behavior of the real core
- Adjusted intermediate communicators and pubsub to preserve the envelop across the proxy
- Added unit test for IPC request to core-mock-server
- Linted all files committed