### PR TITLE
BUG: fix HTTP:413 PayloadTooLargeError: request entity too large

### DIFF
--- a/src/client_api/JsonRpcServer.js
+++ b/src/client_api/JsonRpcServer.js
@@ -126,7 +126,8 @@ class JsonRpcServer extends EventEmitter {
   listen() {
     this._logger.debug('JsonRpcServer listening on port ' + this._port);
     this._app.use(cors({methods: ['POST']}));
-    this._app.use(bodyParser.json());
+    this._app.use(bodyParser.json({limit: '5mb'}));
+    this._app.use(bodyParser.urlencoded({limit: '5mb', extended: true}));
     this._app.use(this._server.middleware());
     this._serverInstance = this._app.listen(this._port);
   }


### PR DESCRIPTION
the limit for the payload for the JsonRPC server is set by default at 100kB.
Increased to 5MB