### PR TITLE
BLD: adjusting to core & ppal msgs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "temp-dir": "/tmp/enigma-p2p"
   },
   "scripts": {
-    "test": "find ./test -name '*_test.js' | npx nyc xargs mocha -R spec --timeout 500000",
+    "test": "find ./test -name '*_test.js' | npx nyc xargs mocha -R spec --timeout 100000",
     "report-coverage": "npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov",
     "lint": "eslint src",
     "lint:fix": "eslint --fix src",

--- a/src/core/core_messages_scheme.json
+++ b/src/core/core_messages_scheme.json
@@ -164,7 +164,6 @@
         "items": {"type": "string"}
       }
     },
-    "required": ["input"],
     "additionalProperties": false
   },
   "PTTResponse": {

--- a/src/core/core_messages_scheme.json
+++ b/src/core/core_messages_scheme.json
@@ -130,13 +130,7 @@
           "userDHKey": {"type": "string"},
           "gasLimit": {"type": "number"},
           "contractAddress": {"type": "string"},
-          "preCode": {
-            "type": "array",
-            "items": {
-              "type": "number",
-              "minItems": 1
-            }
-          }
+          "preCode": {"type": "string"}
         },
         "required": ["preCode", "encryptedArgs", "encryptedFn", "userDHKey", "gasLimit", "contractAddress"],
         "additionalProperties": false
@@ -163,7 +157,16 @@
     "required": ["input"],
     "additionalProperties": false
   },
-  "GetPTTRequest": {},
+  "GetPTTRequest": {
+    "properties":{
+      "input": {
+        "type": "array",
+        "items": {"type": "string"}
+      }
+    },
+    "required": ["input"],
+    "additionalProperties": false
+  },
   "PTTResponse": {
     "properties": {
       "input": {

--- a/src/policy/p2p_messages/principal_messages.js
+++ b/src/policy/p2p_messages/principal_messages.js
@@ -22,10 +22,7 @@ class MsgPrincipal {
   }
 
   toJson() {
-    return {
-      'requestMessage': this.getRequest(),
-      'workerSig': this.getSig(),
-    };
+    return [this.getRequest(),this.getSig()];
   }
 }
 

--- a/src/policy/p2p_messages/principal_messages.js
+++ b/src/policy/p2p_messages/principal_messages.js
@@ -22,7 +22,10 @@ class MsgPrincipal {
   }
 
   toJson() {
-    return [this.getRequest(),this.getSig()];
+    return {
+      'data': this.getRequest(),
+      'sig': this.getSig(),
+    };
   }
 }
 

--- a/src/worker/controller/actions/GetStateKeysAction.js
+++ b/src/worker/controller/actions/GetStateKeysAction.js
@@ -18,7 +18,12 @@ class GetStateKeysAction {
   }
 
   execute(params) {
-    let onResponse = params.onResponse;
+    let onResponse;
+    try {   // We account for the fact that params may be undefined
+      onResponse = params.onResponse;
+    } catch (e) {
+      onResponse = () => {};
+    }
     if (!onResponse) {
       onResponse = () => {};
     }
@@ -37,7 +42,7 @@ class GetStateKeysAction {
         principalResponse = await this._controller.principal().getStateKeys(msg);
       } catch (err) {
         // TODO: Errors.
-        this._controller.logger().error(`Failed Principal node connection: ${err}`);
+        this._controller.logger().error(`Failed Principal node connection: ${err.code} - ${err.message}`);
         return onResponse(err, null);
       }
       this._pttResponse({response: principalResponse.data, sig: principalResponse.sig}, (err, response) => {

--- a/src/worker/controller/actions/GetStateKeysAction.js
+++ b/src/worker/controller/actions/GetStateKeysAction.js
@@ -56,13 +56,24 @@ class GetStateKeysAction {
       });
     };
 
-    this._controller.execCmd(
-        constants.NODE_NOTIFICATIONS.DB_REQUEST,
-        {
-          dbQueryType: constants.CORE_REQUESTS.GetPTTRequest,
-          onResponse: onPTTRequestResponse,
-        },
-    );
+    if (params && params.addresses) {
+      this._controller.execCmd(
+          constants.NODE_NOTIFICATIONS.DB_REQUEST,
+          {
+            dbQueryType: constants.CORE_REQUESTS.GetPTTRequest,
+            input: params.addresses,
+            onResponse: onPTTRequestResponse,
+          },
+      );
+    } else {
+      this._controller.execCmd(
+          constants.NODE_NOTIFICATIONS.DB_REQUEST,
+          {
+            dbQueryType: constants.CORE_REQUESTS.GetPTTRequest,
+            onResponse: onPTTRequestResponse,
+          },
+      );
+    }
   }
 
   _pttResponse(params, cb) {

--- a/src/worker/controller/actions/GetStateKeysAction.js
+++ b/src/worker/controller/actions/GetStateKeysAction.js
@@ -19,13 +19,10 @@ class GetStateKeysAction {
 
   execute(params) {
     let onResponse;
-    try {   // We account for the fact that params may be undefined
-      onResponse = params.onResponse;
-    } catch (e) {
-      onResponse = () => {};
-    }
-    if (!onResponse) {
-      onResponse = () => {};
+    if (params && params.onResponse) {
+      onResponse = params.onResponse 
+    } else {
+        onResponse = () => {};
     }
     const onPTTRequestResponse = async (err, coreResponse) => {
       if (err || coreResponse.type === 'Error') {

--- a/test/ipc_test.js
+++ b/test/ipc_test.js
@@ -59,7 +59,7 @@ it('#2 GetRegistrationParams - mock server', async function() {
     const uri = 'tcp://127.0.0.1:5556';
     const coreServer = new CoreServer();
     coreServer.runServer(uri);
-    await nodeUtils.sleep(100);
+    await nodeUtils.sleep(1000);
     // start the client
     const channels = Channel.biDirectChannel();
     const c1 = channels.channel1;
@@ -80,7 +80,7 @@ it('#2 GetRegistrationParams - mock server', async function() {
           resolve();
         });
   });
-}, 20000);
+}).timeout(10000);;
 
 it('#3 GetAllTips - mock server', async function() {
   const tree = TEST_TREE['ipc'];
@@ -119,7 +119,7 @@ it('#3 GetAllTips - mock server', async function() {
       resolve();
     });
   });
-}, 30000);
+}).timeout(10000);
 
 it('#4 getNewTaskEncryptionKey - mock server', async function() {
   const tree = TEST_TREE['ipc'];
@@ -154,4 +154,4 @@ it('#4 getNewTaskEncryptionKey - mock server', async function() {
           resolve();
         });
   });
-});
+}).timeout(10000);

--- a/test/jsonrpc_advanced_test.js
+++ b/test/jsonrpc_advanced_test.js
@@ -107,7 +107,7 @@ describe('jsonrpc_advanced',()=>{
 function getDeployRequest(signKey){
   return {
     contractAddress : '0x4409b216c78f20a2755240a73b7903825db9a6f985bcce798381aef58d740521',
-    preCode : [22,33,100,202,111,223,211,22],
+    preCode : '162164ca6fdfd316',
     workerAddress : signKey,
     encryptedFn : 'be3e4462e79ccdf05b02e0921731c5f9dc8dce554b861cf5a05a5162141d63e1f4b1fac190828367052b198857aba9e10cdad79d95',
     encryptedArgs : 'fd50f5f6cd8b7e2b30547e70a84b61faaebf445927b70a743f23bf10342da00b7d8a20948c6c3aec7c54edba52298d90',

--- a/test/jsonrpc_test.js
+++ b/test/jsonrpc_test.js
@@ -207,7 +207,7 @@ describe('JsonRPC tests', () => {
         encryptedFn: 'be3e4462e79ccdf05b02e0921731c5f9dc8dce554b861cf5a05a5162141d63e1f4b1fac190828367052b198857aba9e10cdad79d95',
         encryptedArgs: 'fd50f5f6cd8b7e2b30547e70a84b61faaebf445927b70a743f23bf10342da00b7d8a20948c6c3aec7c54edba52298d90',
         userDHKey: '5587fbc96b01bfe6482bf9361a08e84810afcc0b1af72a8e4520f98771ea1080681e8a2f9546e5924e18c047fa948591dba098bffaced50f97a41b0050bdab99',
-        preCode : [22,33,100,202,111,223,211,22]
+        preCode : '162164ca6fdfd316'
       };
       JsonRpcClient.request('deploySecretContract',deployInput,(err,res)=>{
         assert.strictEqual(true,res.sendTaskResult, "sendTaskResult not true");
@@ -226,7 +226,7 @@ describe('JsonRPC tests', () => {
         encryptedFn: 'be3e4462e79ccdf05b02e0921731c5f9dc8dce554b861cf5a05a5162141d63e1f4b1fac190828367052b198857aba9e10cdad79d95',
         encryptedArgs: 'fd50f5f6cd8b7e2b30547e70a84b61faaebf445927b70a743f23bf10342da00b7d8a20948c6c3aec7c54edba52298d90',
         userDHKey: '5587fbc96b01bfe6482bf9361a08e84810afcc0b1af72a8e4520f98771ea1080681e8a2f9546e5924e18c047fa948591dba098bffaced50f97a41b0050bdab99',
-        preCode : [22,33,100,202,111,223,211,22]
+        preCode : '162164ca6fdfd316'
       };
       JsonRpcClient.request('deploySecretContract',deployInput,(err,res)=>{
         assert.strictEqual(-32602, err.code, "code dont match");
@@ -243,7 +243,7 @@ describe('JsonRPC tests', () => {
       await testUtils.sleep(1500);
       const deployInput = {
         contractAddress: '0x9209b216c78f20a2755240a73b7903825db9a6f985bcce798381aef58d74059e',
-        preCode : [22,33,100,202,111,223,211,22],
+        preCode : '162164ca6fdfd316',
         workerAddress: signKey,
         encryptedFn: 'be3e4462e79ccdf05b02e0921731c5f9dc8dce554b861cf5a05a5162141d63e1f4b1fac190828367052b198857aba9e10cdad79d95',
         encryptedArgs: 'fd50f5f6cd8b7e2b30547e70a84b61faaebf445927b70a743f23bf10342da00b7d8a20948c6c3aec7c54edba52298d90',

--- a/test/principal_test.js
+++ b/test/principal_test.js
@@ -66,7 +66,7 @@ it('#2 Should Simulate the principal node and run GetStateKeysAction', async fun
 function getMockPrincipalNode() {
   const server = jayson.server({
     getStateKeys: function(args, callback) {
-      if (args.requestMessage && args.workerSig) {
+      if (args.data && args.sig) {
         recivedRequest = true;
         const result = {data: fakeResponse, sig: fakeSig};
         callback(null, result);


### PR DESCRIPTION
* Adds scheme for `GetPTTRequest` that was empty
* Adjusts scheme for `preCode` in `DeploySecretContract` that comes in as a hex string from core, instead of the byte array.
* Adjusts the specs for the message to the KeyMgmgt node that is an array, instead of an object
* And in `GetStateKeysAction.js` accounts for being called without specifying `params` which would otherwise throw an error around L21, and unpacks the error object and displays it properly in L45 