### PR TITLE
Adjusting commitReceipt for empty StateDelta

### DIFF
--- a/src/ethereum/EnigmaContractWriterAPI.js
+++ b/src/ethereum/EnigmaContractWriterAPI.js
@@ -285,6 +285,9 @@ class EnigmaContractWriterAPI extends EnigmaContractReaderAPI {
       if(!optionalEthereumData) {
         optionalEthereumData = '0x';   // This is the right value to pass an empty value to the contract, otherwise we get an error
       }
+      if(!stateDeltaHash) {
+        stateDeltaHash = '0x';
+      }
       this._enigmaContract.methods.commitReceipt(
         utils.add0x(secretContractAddress),
         utils.add0x(taskId),

--- a/src/ethereum/EnigmaContractWriterAPI.js
+++ b/src/ethereum/EnigmaContractWriterAPI.js
@@ -5,6 +5,8 @@ const EnigmaContractReaderAPI = require('./EnigmaContractReaderAPI');
 // TODO:: delegate the configuration load to the caller from the outside + allow dynamic path (because the caller is responsible).
 const config = require('./config.json');
 
+const EMPTY_HEX_STRING = '0x'; // This is the right value to pass an empty value to the contract, otherwise we get an error
+
 class EnigmaContractWriterAPI extends EnigmaContractReaderAPI {
   constructor(enigmaContractAddress, enigmaContractABI, web3, logger) {
     super(enigmaContractAddress, enigmaContractABI, web3, logger);
@@ -119,7 +121,7 @@ class EnigmaContractWriterAPI extends EnigmaContractReaderAPI {
       }
 
       if(!optionalEthereumData) {
-        optionalEthereumData = '0x';   // This is the right value to pass an empty value to the contract, otherwise we get an error
+        optionalEthereumData = EMPTY_HEX_STRING;
       }
 
       this._enigmaContract.methods.deploySecretContract(
@@ -283,10 +285,10 @@ class EnigmaContractWriterAPI extends EnigmaContractReaderAPI {
         transactionOptions = defaultsDeep(txParams, defaultOptions);
       }
       if(!optionalEthereumData) {
-        optionalEthereumData = '0x';   // This is the right value to pass an empty value to the contract, otherwise we get an error
+        optionalEthereumData = EMPTY_HEX_STRING;
       }
       if(!stateDeltaHash) {
-        stateDeltaHash = '0x';
+        stateDeltaHash = EMPTY_HEX_STRING;
       }
       this._enigmaContract.methods.commitReceipt(
         utils.add0x(secretContractAddress),

--- a/src/worker/controller/actions/ethereum/CommitReceiptAction.js
+++ b/src/worker/controller/actions/ethereum/CommitReceiptAction.js
@@ -34,12 +34,12 @@ class CommitReceiptAction {
     });
   }
   _commitTask(task, txParams) {
-    if (task.getResult().isSuccess() && task.getResult().getDelta().data && task.getResult().getOutput()) {
+    if (task.getResult().isSuccess() && task.getResult().getOutput()) {
       return this._commitSuccessTask(task, txParams);
     } else if (task.getResult().isFailed()) {
       return this._commitFailedTask(task, txParams);
     }
-    throw errors.TypeErr(`wrong type or missing fields in Result`);
+    throw new errors.TypeErr(`wrong type or missing fields in Result`);
   }
   _commitFailedTask(task, txParams) {
     if(task instanceof DeployTask) {


### PR DESCRIPTION
For those computations that do not change the State, the delta is empty, so removed the condition for delta to be present to commitReceipt, and changed empty value to `0x` to please the contract.
Also added the needed `new` to TypeErr, otherwise I got an exception.

As discussed offline with @elichai.