### PR TITLE
TST: adjust overall timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "temp-dir": "/tmp/enigma-p2p"
   },
   "scripts": {
-    "test": "find ./test -name '*_test.js' | npx nyc xargs mocha -R spec --timeout 100000",
+    "test": "find ./test -name '*_test.js' | npx nyc xargs mocha -R spec --timeout 200000",
     "report-coverage": "npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov",
     "lint": "eslint src",
     "lint:fix": "eslint --fix src",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "temp-dir": "/tmp/enigma-p2p"
   },
   "scripts": {
-    "test": "find ./test -name '*_test.js' | npx nyc xargs mocha -R spec --timeout 500000",
+    "test": "find ./test -name '*_test.js' | npx nyc xargs mocha -R spec --timeout 100000",
     "report-coverage": "npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov",
     "lint": "eslint src",
     "lint:fix": "eslint --fix src",


### PR DESCRIPTION
Reduce overall timeout for unit tests. The timeout is set to an unnecessarily large number: 500s. The longest single unit tests runs for about 60s. We can safely cut the overall time out by 5, to 100s, and still don't affect any of the tests that pass. 

The issue here is when a test fails for some reason and doesn't exit cleanly, we have to wait for the overall timeout, limiting us how many test (for different commits/branches/PRs) we can run in parallel.