### PR TITLE
MAINT: increase upload limit

### DIFF
--- a/src/client_api/JsonRpcServer.js
+++ b/src/client_api/JsonRpcServer.js
@@ -143,8 +143,8 @@ class JsonRpcServer extends EventEmitter {
   listen() {
     this._logger.debug('JsonRpcServer listening on port ' + this._port);
     this._app.use(cors({methods: ['POST']}));
-    this._app.use(bodyParser.json({limit: '5mb'}));
-    this._app.use(bodyParser.urlencoded({limit: '5mb', extended: true}));
+    this._app.use(bodyParser.json({limit: '20mb'}));
+    this._app.use(bodyParser.urlencoded({limit: '20mb', extended: true}));
     this._app.use(this._server.middleware());
     this._serverInstance = this._app.listen(this._port);
   }


### PR DESCRIPTION
Analogous to #54, increasing it even more.

After [125](https://github.com/enigmampc/enigma-core/pull/125) in `core`, the ERC20 contract fails to deploy because of `PayloadTooLargeError: request entity too large`. 

This fixes it.

PS: we should probably start compressing the contract bytecode soon, before this becomes too large, but this will work for now.