### PR TITLE
Updated GetPTTRequest to fully support and verify optional addresses

### DIFF
--- a/src/core/actions/DbRead/GetDbAction.js
+++ b/src/core/actions/DbRead/GetDbAction.js
@@ -7,15 +7,15 @@ class GetDbAction{
     this._coreRuntime = coreRuntime;
   }
 
-  execute(envelop){
-    let request = {
-      id : nodeUtils.randId(),
-      type :envelop.content().type,
-      input : envelop.content().input
+  execute(envelop) {
+    const request = {
+      id: envelop.content().id,
+      type: envelop.content().type,
+      input: envelop.content().input,
     };
-    this._coreRuntime.execCmd(Msg.CORE_DB_ACTION,{
-      envelop : envelop,
-      sendMsg : request,
+    this._coreRuntime.execCmd(Msg.CORE_DB_ACTION, {
+      envelop: envelop,
+      sendMsg: request,
     });
     // let client = this._coreRuntime.getIpcClient();
     // client.sendJsonAndReceive(,(responseMsg)=>{

--- a/src/core/core_messages_scheme.json
+++ b/src/core/core_messages_scheme.json
@@ -163,7 +163,21 @@
     "required": ["input"],
     "additionalProperties": false
   },
-  "GetPTTRequest": {},
+  "GetPTTRequest": {
+    "properties": {
+      "input": {
+        "type": "object",
+        "properties": {
+          "addresses": {
+            "type": "array",
+            "minItems": 1
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "additionalProperties": false
+  },
   "PTTResponse": {
     "properties": {
       "input": {

--- a/src/core/core_server_mock/core_server.js
+++ b/src/core/core_server_mock/core_server.js
@@ -55,11 +55,17 @@ class MockCoreServer {
 
   static _getPTTRequest(msg) {
     if (MockCoreServer._validate(msg, SCHEMES.GetPTTRequest)) {
+      let request;
+      if (msg.input && msg.input.addresses) {
+        request = msg.input.addresses;
+      } else {
+        request = MockCoreServer.GET_PTT_NO_ADDRESSES_REQUEST_MOCK;
+      }
       return {
         id: msg.id,
         type: msg.type,
         result: {
-          request: 'the-message-packed-request',
+          request: request,
           workerSig: 'the-worker-sig',
         },
       };

--- a/src/core/core_server_mock/core_server.js
+++ b/src/core/core_server_mock/core_server.js
@@ -11,6 +11,7 @@ const validate = require('jsonschema').validate;
 const SCHEMES = require('../core_messages_scheme');
 
 
+
 class MockCoreServer {
   constructor(name) {
     this._socket = null;
@@ -46,6 +47,10 @@ class MockCoreServer {
       type: 'Error',
       msg: 'Message Error, Type: ' + msg.type,
     };
+  }
+
+  static get GET_PTT_NO_ADDRESSES_REQUEST_MOCK() {
+    return 'no addresses';
   }
 
   static _getPTTRequest(msg) {

--- a/src/main_controller/channels/Envelop.js
+++ b/src/main_controller/channels/Envelop.js
@@ -21,11 +21,13 @@ class Envelop {
       this._id = sequenceOrId;
     } else if (sequenceOrId === true) { // initialize a request with id for response
       this._id = nodeUtils.randId();
+    } else {
+      console.log('[-] error initializing envelop sequenceOrId must be either a string ID or a `true` to generate one randomally!');
+      this._validEnvelop = false;
     }
-
     // attach id to msg if missing
-    if(!('id' in this._obj) && this._id !== false){
-      this._obj.id = this._id;
+    if (!('id' in this._obj) && this._id !== false) {
+      this._obj.id = nodeUtils.randId();
     }
   }
   isValidEnvelop(){

--- a/src/worker/controller/actions/GetStateKeysAction.js
+++ b/src/worker/controller/actions/GetStateKeysAction.js
@@ -9,6 +9,9 @@ class GetStateKeysAction {
   async asyncExecute(params) {
     const action = this;
     return new Promise((resolve, reject) => {
+      if (!params) {
+        params = {};
+      }
       params.onResponse = function(err, data) {
         if (err) reject(err);
         else resolve(data);
@@ -20,7 +23,7 @@ class GetStateKeysAction {
   execute(params) {
     let onResponse;
     if (params && params.onResponse) {
-      onResponse = params.onResponse
+      onResponse = params.onResponse;
     } else {
       onResponse = () => {};
     }
@@ -62,10 +65,9 @@ class GetStateKeysAction {
     };
 
     if (params && params.addresses) {
-      dbRequestParams.input = params.addresses;
+      dbRequestParams.input = {addresses: params.addresses};
     }
     this._controller.execCmd(constants.NODE_NOTIFICATIONS.DB_REQUEST, dbRequestParams);
-
   }
 
   _pttResponse(params, cb) {

--- a/test/ipc_test.js
+++ b/test/ipc_test.js
@@ -147,7 +147,8 @@ it('#4 getNewTaskEncryptionKey - mock server', async function() {
     c1.sendAndReceive(reqEnv)
         .then((resEnv)=>{
           expect(resEnv.content().type).toBe(constants.CORE_REQUESTS.NewTaskEncryptionKey);
-          expect(resEnv.content().id).toBe(reqEnv._id);
+          expect(resEnv.id()).toBe(reqEnv.id());
+          expect(resEnv.content().id).toBe(reqEnv.content().id);
           expect(resEnv.content().result.workerEncryptionKey).toBeTruthy();
           expect(resEnv.content().result.workerSig).toBeTruthy();
           coreRuntime.disconnect();

--- a/test/principal_test.js
+++ b/test/principal_test.js
@@ -6,6 +6,7 @@ const assert = require('assert');
 const PrincipalNode = require('../src/worker/handlers/PrincipalNode');
 const MsgPrincipal = require('../src/policy/p2p_messages/principal_messages');
 const constants = require('../src/common/constants');
+const expect = require('expect');
 
 const fakeResponse = '0061d93b5412c0c9';
 const fakeRequest = '84a46461746181a';
@@ -29,6 +30,8 @@ it('#1 Should Recieve Encrypted response message from mock principal', async fun
 
     const principalClient = new PrincipalNode({uri: uri + port});
     const msg = MsgPrincipal.build({request: fakeRequest, sig: fakeSig});
+    response = fakeRequest;
+
     const result = await principalClient.getStateKeys(msg);
     assert.strictEqual(result.data, fakeResponse);
     assert.strictEqual(result.sig, fakeSig);
@@ -53,6 +56,8 @@ it('#2 Should Simulate the principal node and run GetStateKeysAction', async fun
     const controllers = await ControllerBuilder.createNode(nodeConfig);
     const mainController = controllers.mainController;
 
+    response = addresses;
+
     await mainController.getNode().asyncExecCmd(
         constants.NODE_NOTIFICATIONS.GET_STATE_KEYS,
         {addresses: addresses},
@@ -69,6 +74,7 @@ it('#2 Should Simulate the principal node and run GetStateKeysAction', async fun
 function getStateKeysCallback(args, callback) {
   if (args.data && args.sig) {
     receivedRequest = true;
+    expect(args.data).toEqual(response);
     const result = {data: fakeResponse, sig: fakeSig};
     callback(null, result);
   } else {

--- a/test/test_tree.js
+++ b/test/test_tree.js
@@ -11,6 +11,8 @@ module.exports.TEST_TREE = {
     '#2' : true,
     '#3' : true,
     '#4': true,
+    '#5': true,
+    '#6': true,
   },
   'coverage' :{
     'all' : true,


### PR DESCRIPTION
- Updated the `core_messages_scheme.json` scheme to support and verify optional addresses in `GetPTTRequest`
- Added more tests for this part of the IPC
- Updated the existing principal tests and fixed some bugs.

This should Fix #123 and #157
@lacabra 