### PR TITLE
BLD: adjusted getWorkerParams

### DIFF
--- a/src/ethereum/EthereumVerifier.js
+++ b/src/ethereum/EthereumVerifier.js
@@ -7,6 +7,7 @@ const cryptography = require('../common/cryptography');
 const JSBI = require('jsbi');
 const abi = require('ethereumjs-abi');
 const errors = require('../common/errors');
+const nodeUtils = require('../common/utils');
 
 const result = require('../worker/tasks/Result');
 const Result = result.Result;
@@ -337,8 +338,8 @@ class EthereumVerifier {
   _verifySelectedWorker(secretContractAddress, workerAddress, params) {
     let result = {error: null, isVerified: true};
     let selectedWorker = EthereumVerifier.selectWorkerGroup(secretContractAddress, params, 1)[0];
-    // selectedWorker = nodeUtils.remove0x(selectedWorker.signer.toLowerCase());  // To enable in update to the contract
-    if (selectedWorker.signer !== workerAddress) {
+    selectedWorker = nodeUtils.remove0x(selectedWorker.toLowerCase());
+    if (selectedWorker !== workerAddress) {
       const err = new errors.WorkerSelectionVerificationErr("Not the selected worker for the " + secretContractAddress + " task");
       result.error = err;
       result.isVerified = false;

--- a/test/ethereum/utils.js
+++ b/test/ethereum/utils.js
@@ -4,6 +4,7 @@ const web3Utils = require('web3-utils');
 const crypto = require('../../src/common/cryptography');
 const DB_PROVIDER = require('../../src/core/core_server_mock/data/provider_db');
 const DbUtils = require('../../src/common/DbUtils');
+const nodeUtils = require('../../src/common/utils');
 
 
 function runSelectionAlgo(secretContractAddress, seed, nonce, balancesSum, balances, workers) {
@@ -72,16 +73,16 @@ module.exports.createDataForTaskSubmission = function() {
 }
 
 module.exports.createDataForSelectionAlgorithm = function() {
-  const workersA = [{signer: web3Utils.toChecksumAddress(web3Utils.randomHex(20))},
-    {signer: web3Utils.toChecksumAddress(web3Utils.randomHex(20))},
-    {signer: web3Utils.toChecksumAddress(web3Utils.randomHex(20))},
-    {signer: web3Utils.toChecksumAddress(web3Utils.randomHex(20))},
-    {signer: web3Utils.toChecksumAddress(web3Utils.randomHex(20))}];
-  const workersB = [{signer: web3Utils.toChecksumAddress(web3Utils.randomHex(20))},
-    {signer: web3Utils.toChecksumAddress(web3Utils.randomHex(20))},
-    {signer: web3Utils.toChecksumAddress(web3Utils.randomHex(20))},
-    {signer: web3Utils.toChecksumAddress(web3Utils.randomHex(20))},
-    {signer: web3Utils.toChecksumAddress(web3Utils.randomHex(20))}];
+  const workersA = [nodeUtils.remove0x(web3Utils.randomHex(20).toLowerCase()),
+    nodeUtils.remove0x(web3Utils.randomHex(20).toLowerCase()),
+    nodeUtils.remove0x(web3Utils.randomHex(20).toLowerCase()),
+    nodeUtils.remove0x(web3Utils.randomHex(20).toLowerCase()),
+    nodeUtils.remove0x(web3Utils.randomHex(20).toLowerCase())];
+  const workersB = [nodeUtils.remove0x(web3Utils.randomHex(20).toLowerCase()),
+    nodeUtils.remove0x(web3Utils.randomHex(20).toLowerCase()),
+    nodeUtils.remove0x(web3Utils.randomHex(20).toLowerCase()),
+    nodeUtils.remove0x(web3Utils.randomHex(20).toLowerCase()),
+    nodeUtils.remove0x(web3Utils.randomHex(20).toLowerCase())];
 
   const balancesA = [crypto.toBN(1), crypto.toBN(2), crypto.toBN(3), crypto.toBN(4), crypto.toBN(5)];
   const balancesB = [crypto.toBN(5), crypto.toBN(4), crypto.toBN(3), crypto.toBN(2), crypto.toBN(1)];
@@ -99,7 +100,7 @@ module.exports.createDataForSelectionAlgorithm = function() {
 
   const secretContractAddress = web3Utils.randomHex(32);
 
-  const expected = runSelectionAlgo(secretContractAddress, seed, nonce, balancesSum, balancesA, workersA).signer;
+  const expected = runSelectionAlgo(secretContractAddress, seed, nonce, balancesSum, balancesA, workersA);
 
   return {params: params,
     expectedAddress: expected,

--- a/test/verifier_test.js
+++ b/test/verifier_test.js
@@ -501,7 +501,7 @@ describe('Verifier tests', function() {
 
       // 1.Verify only the algorithm
       const observed = EthereumVerifier.selectWorkerGroup(a.secretContractAddress, a.expectedParams, 1)[0];
-      assert.strictEqual(observed.signer, a.expectedAddress);
+      assert.strictEqual(observed, a.expectedAddress);
 
       // 2. Verify the entire flow of params update
       let blockNumber = a.expectedParams.firstBlockNumber + 50;


### PR DESCRIPTION
When querying the contract for `getWorkerParams()`, the contract returns:
```
      [ firstBlockNumber: '31',
        workers: [],
        stakes: [],
        seed: '31268644497779061311222352809693212829739556404064854661798104869398319621808' ],
      [ firstBlockNumber: '45',
        workers: [ '0x5C294ddf21c8b775E8ED81E0589F0e92E93648B9' ],
        stakes: [ '90000000000' ],
        seed: '13550632963218223449517008427752132222765922947913621029990270263125959160203' ],
```
where the worker addresses are an array, instead of an array of objects of the type `signer: address` which is what P2P was expecting up until now. 

Made the necessary adjustments in the code and the unit tests