### PR TITLE
BUG: fix workerSelection algo

### DIFF
--- a/src/ethereum/EthereumVerifier.js
+++ b/src/ethereum/EthereumVerifier.js
@@ -365,11 +365,11 @@ class EthereumVerifier {
       // Unique hash for epoch, secret contract address, and nonce
       const hash = cryptography.hash(abi.rawEncode(
           ['uint256', 'bytes32', 'uint256'],
-          [params.seed, secretContractAddress, nonce]
+          [params.seed, nodeUtils.add0x(secretContractAddress), nonce]
         ));
 
       // Find random number between [0, tokenCpt)
-      let randVal = JSBI.remainder(cryptography.toBN(hash), cryptography.toBN(tokenCpt));
+      let randVal = JSBI.remainder(cryptography.toBN(hash), tokenCpt);
       let selectedWorker = params.workers[params.workers.length - 1];
       // Loop through each worker, subtracting worker's balance from the random number computed above. Once the
       // decrementing randVal becomes negative, add the worker whose balance caused this to the list of selected


### PR DESCRIPTION
Fixes the discrepancy between the workerSelection algorithm in P2P and the contract, as reported in [this Issue](https://github.com/enigmampc/discovery-integration-tests/issues/6). The culprit is that in order for the secretContractAddress to be treated as `bytes` for the `abi.rawEncode()` function it has to be prepended by `0x` otherwise it gets treated as a string. 

The following code snippet illustrates the difference (scroll right to see where the output of msg differs/matches the same bytes as the scAddr)
```
const abi = require('ethereumjs-abi');
const web3Utils = require('web3-utils');


const seed = '109725390239314756449905043124515690987747101341339396972907487788798516464146';
const scAddr = '85da6ff194ad23304f3b7fe2c7c1a9e728154deadbf92d620c242b0c55a4f961'
const nonce = 0;

let msg = abi.rawEncode(
  ['uint256', 'bytes32', 'uint256'],
  [seed, scAddr, nonce],
);
console.log(msg);
console.log(web3Utils.keccak256(msg));
// WRONNG OUTPUT:
// <Buffer f2 96 5e bb 9f 58 20 86 d5 fa 73 62 2e 20 3b 41 e7 76 13 fa d6 cd e7 58 af b6 c2 84 c7 c9 0a 12 38 35 64 61 36 66 66 31 39 34 61 64 32 33 33 30 34 66 ... >
// 0x9eadff465d107c35bbbb7ceed1714517eddb2d775fc74616b5c9d4e801d72451                                      ^^^^^^-->

msg = abi.rawEncode(
  ['uint256', 'bytes32', 'uint256'],
  [seed, '0x'+scAddr, nonce],
);
console.log(msg);
console.log(web3Utils.keccak256(msg));
// CORRECT OUTPUT:
// <Buffer f2 96 5e bb 9f 58 20 86 d5 fa 73 62 2e 20 3b 41 e7 76 13 fa d6 cd e7 58 af b6 c2 84 c7 c9 0a 12 85 da 6f f1 94 ad 23 30 4f 3b 7f e2 c7 c1 a9 e7 28 15 ... >
// 0x11150337faee3b6cde6d3293c3279c2948d13f190b3a3892075577ce55bf6905                                      ^^^^^^-->
```