### PR TITLE
BUG: fix BN broken in recent dep upgrade

### DIFF
--- a/src/ethereum/EnigmaContractReaderAPI.js
+++ b/src/ethereum/EnigmaContractReaderAPI.js
@@ -340,7 +340,7 @@ class EnigmaContractReaderAPI {
        * */
       'WorkersParameterized': (event) => {
         return {
-          seed: event.returnValues.seed,
+          seed: cryptography.toBN(event.returnValues.seed),
           firstBlockNumber: parseInt(event.returnValues.firstBlockNumber),
           inclusionBlockNumber: parseInt(event.returnValues.inclusionBlockNumber),
           workers: event.returnValues.workers,

--- a/src/ethereum/EthereumVerifier.js
+++ b/src/ethereum/EthereumVerifier.js
@@ -365,7 +365,7 @@ class EthereumVerifier {
       // Unique hash for epoch, secret contract address, and nonce
       const hash = cryptography.hash(abi.rawEncode(
           ['uint256', 'bytes32', 'uint256'],
-          [params.seed, nodeUtils.add0x(secretContractAddress), nonce]
+          [params.seed.toString(10), nodeUtils.add0x(secretContractAddress), nonce]
         ));
 
       // Find random number between [0, tokenCpt)


### PR DESCRIPTION
@AvishaiW reported the following today: 
```
p2p_1        | (node:41) UnhandledPromiseRejectionWarning: Error: Argument is not a number
p2p_1        |     at parseNumber (/root/enigma-p2p/node_modules/ethereumjs-abi/lib/index.js:75:11)
p2p_1        |     at encodeSingle (/root/enigma-p2p/node_modules/ethereumjs-abi/lib/index.js:168:11)
p2p_1        |     at Function.ABI.rawEncode (/root/enigma-p2p/node_modules/ethereumjs-abi/lib/index.js:368:15)
p2p_1        |     at Function.selectWorkerGroup (/root/enigma-p2p/src/ethereum/EthereumVerifier.js:366:42)
p2p_1        |     at EthereumVerifier._verifySelectedWorker (/root/enigma-p2p/src/ethereum/EthereumVerifier.js:340:43)
p2p_1        |     at Promise (/root/enigma-p2p/src/ethereum/EthereumVerifier.js:137:24)
p2p_1        |     at new Promise (<anonymous>)
p2p_1        |     at EthereumVerifier.verifySelectedWorker (/root/enigma-p2p/src/ethereum/EthereumVerifier.js:130:12)
p2p_1        |     at _verifyTaskCreationNow.then (/root/enigma-p2p/src/ethereum/EthereumVerifier.js:69:35)
p2p_1        |     at processTicksAndRejections (internal/process/task_queues.js:86:5)
p2p_1        | (node:41) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
p2p_1        | (node:41) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
which I attributed to the upgrade from #178.

So I'm treating the seed we get from the contract as a JSBI BigNumber and then converting it to string base10 so that the encoder can convert the string to a BN [here](https://github.com/ethereumjs/ethereumjs-abi/blob/8431eab7b3384e65e8126a4602520b78031666fb/lib/index.js#L67). Eventually web3 will adopt JSBI, and the `toString(10)` on L368 will be unnecessary as we will be able to pass a JSBI directly, but this is not yet possible.

I am updating the homologous code in EnigmaJS accordingly for consistency: [Issue 90](https://github.com/enigmampc/enigma-contract/pull/90)