### PR TITLE
MAINT: license npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test-tree": "node scripts/test_tree_validation.js"
   },
   "author": "isan rivkin",
-  "license": "ISC",
+  "license": "AGPL-3.0-or-later",
   "dependencies": {
     "@nodeutils/defaults-deep": "^1.1.0",
     "async": "^2.6.1",


### PR DESCRIPTION
Updated the license for the npm package associated to this repo to match the repo license, using the proper SPDX identifier as documented [here](https://docs.npmjs.com/files/package.json#license).

@lenak25 as a result of this PR, I would ask you to push a new release of the `enigma-p2p` npm package since the license of the currently published package is wrong. Thanks