### PR TITLE
Add "UpdateNewContractOnDeployment" IPC

### DIFF
--- a/docs/IPC_MESSAGES.md
+++ b/docs/IPC_MESSAGES.md
@@ -190,7 +190,28 @@ Response:
     }
 }
 ```
-
+### `UpdateNewContractOnDeployment` message
+Request:
+```
+{
+    id : <unique_request_id>,
+    type : UpdateNewContractOnDeployment,
+    address : ...,
+    bytecode : [Secret Contract Address]
+    delta : [First delta]
+}
+```
+Response:
+```
+{
+    id : <unique_request_id>,
+    type : UpdateNewContractOnDeployment,
+    address : ...,
+    result : {
+        status : 0 or err code
+    }
+}
+```
 ### `UpdateDeltas` message
 Request:
 ```


### PR DESCRIPTION
Required for updating core on a newly deployed contract - when a deploy result is received. In addition to the contract address and its bytecode, the first delta is also required.