### PR TITLE
TST: moving from 1 to 3 nodes in integrationTests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
     sed -i "s/-vv/-v/" enigma-core/start_core.bash &&
     popd
   - pushd discovery-docker-network/enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=$TRAVIS_BRANCH -t enigmampc/enigma_p2p:$TAG --no-cache . >/dev/null && popd
-  - pushd discovery-docker-network && docker-compose -f docker-compose.yml -f docker-compose.test.yml up --exit-code-from client && popd
+  - pushd discovery-docker-network && NODES=3 docker-compose -f docker-compose.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client && popd
 
 after_success:
   - npm run report-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
     sed -i "s/-vv/-v/" enigma-core/start_core.bash &&
     popd
   - pushd discovery-docker-network/enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=$TRAVIS_BRANCH -t enigmampc/enigma_p2p:$TAG --no-cache . >/dev/null && popd
-  - pushd discovery-docker-network && NODES=3 docker-compose -f docker-compose.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client && popd
+  - pushd discovery-docker-network && export NODES=3 && docker-compose -f docker-compose.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client && popd
 
 after_success:
   - npm run report-coverage


### PR DESCRIPTION
Increasing from `NODES=1` to `NODES=3` to run the integration tests for increased robustness of said tests.

Analogous to:

- enigmampc/discovery-docker-network#39
- enigmampc/enigma-core#226
- enigmampc/enigma-contract#151