### PR TITLE
MAINT: builds match branches across repos

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,12 +4,16 @@ steps:
 
   - name: p2p
     image: node:10
+    environment:
+      CODECOV_TOKEN:
+        from_secret: CODECOV_TOKEN
     commands:
       - apt-get update && apt-get install build-essential
       - npm install -g truffle@5.0.15
       - npm install
       - npm test
-      - if [ ${DRONE_BRANCH} == "develop" ] || [ ${TRAVIS_BRANCH} == "master" ]; then echo $DRONE_BRANCH ; npm run test-tree; fi
+      - if [[ "${DRONE_BRANCH}" == "develop" ]] || [[ "${DRONE_BRANCH}" == "master" ]]; then echo $DRONE_BRANCH ; npm run test-tree; fi
+      - npm run report-coverage
 
   - name: integration
     image: enigmampc/docker-client
@@ -25,59 +29,59 @@ steps:
       - sed -i "s/COMPOSE_PROJECT_NAME=.*/COMPOSE_PROJECT_NAME=enigma_${DRONE_BUILD_NUMBER}/" .env
       - export MATCHING_BRANCH_CONTRACT="$(git ls-remote --heads https://github.com/enigmampc/enigma-contract.git ${DRONE_BRANCH} | wc -l)"
       - export MATCHING_BRANCH_CORE="$(git ls-remote --heads https://github.com/enigmampc/enigma-core.git ${DRONE_BRANCH} | wc -l)"
+      - export DOCKER_TAG=p2p_${DRONE_BUILD_NUMBER}
+      - sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=${DOCKER_TAG}/" .env;
       - |
         if [[ "${DRONE_BRANCH}" == "master" ]]; then
-          export TAG=latest;
-          docker-compose pull
+          docker pull enigmampc/enigma_contract:latest
+          docker pull enigmampc/enigma_core_hw:latest
+          docker pull enigmampc/enigma_km_hw:latest
+          docker tag enigmampc/enigma_contract:latest enigmampc/enigma_contract:$DOCKER_TAG
+          docker tag enigmampc/enigma_core_hw:latest enigmampc/enigma_core_hw:$DOCKER_TAG
+          docker tag enigmampc/enigma_km_hw:latest enigmampc/enigma_km_hw:$DOCKER_TAG
         else
-          if [ $MATCHING_BRANCH_CONTRACT -eq 0 ] &&  [ $MATCHING_BRANCH_CORE -eq 0 ]; then
-            export TAG=develop;
-            sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=develop/" .env;
-            docker-compose pull
+          if [ $MATCHING_BRANCH_CONTRACT -eq 0 ] && [ $MATCHING_BRANCH_CORE -eq 0 ]; then
+            docker pull enigmampc/enigma_contract:develop
+            docker pull enigmampc/enigma_core_hw:develop
+            docker pull enigmampc/enigma_km_hw:develop
+            docker tag enigmampc/enigma_contract:develop enigmampc/enigma_contract:$DOCKER_TAG
+            docker tag enigmampc/enigma_core_hw:develop enigmampc/enigma_core_hw:$DOCKER_TAG
+            docker tag enigmampc/enigma_km_hw:develop enigmampc/enigma_km_hw:$DOCKER_TAG
           else
-            export TAG=${DRONE_BRANCH};
-            sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=${TAG}/" .env;
             if [ $MATCHING_BRANCH_CONTRACT -eq 1 ] && [ $MATCHING_BRANCH_CORE -eq 0 ]; then
-              cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$TAG --no-cache . && cd ..
+              cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$DOCKER_TAG --no-cache . && cd ..
               docker pull enigmampc/enigma_core_hw:develop
-              docker tag enigmampc/enigma_core_hw:develop enigmampc/enigma_core_hw:$TAG
+              docker tag enigmampc/enigma_core_hw:develop enigmampc/enigma_core_hw:$DOCKER_TAG
               docker pull enigmampc/enigma_km_hw:develop
-              docker tag enigmampc/enigma_km_hw:develop enigmampc/enigma_km_hw:$TAG
+              docker tag enigmampc/enigma_km_hw:develop enigmampc/enigma_km_hw:$DOCKER_TAG
             else
               if [ $MATCHING_BRANCH_CONTRACT -eq 0 ] && [ $MATCHING_BRANCH_CORE -eq 1 ]; then
                 cd enigma-core
-                docker build --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$TAG --no-cache .
-                docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$TAG --no-cache .
+                docker build --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$DOCKER_TAG --no-cache .
+                docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$DOCKER_TAG --no-cache .
                 cd ..
                 docker pull enigmampc/enigma_contract:develop
-                docker tag enigmampc/enigma_contract:develop enigmampc/enigma_contract:$TAG
+                docker tag enigmampc/enigma_contract:develop enigmampc/enigma_contract:$DOCKER_TAG
               else
-                cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$TAG --no-cache . && cd ..
+                cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$DOCKER_TAG --no-cache . && cd ..
                 cd enigma-core
-                docker build --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$TAG --no-cache .
-                docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$TAG --no-cache .
+                docker build --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$DOCKER_TAG --no-cache .
+                docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$DOCKER_TAG --no-cache .
                 cd ..
               fi
             fi
           fi
         fi
-      - cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$TAG --no-cache . && cd ..
+      - cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$DOCKER_TAG --no-cache . && cd ..
       - export NODES=3
       - docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client && export RESULT=$? || export RESULT=$?
-      - if [[ "${DRONE_BRANCH}" == "$TAG" ]]; then docker-compose down -v --rmi all; else docker-compose down -v; fi
-      - if [ $RESULT -ne 0 ]; exit 1; fi
-
-  - name: coverage
-    image: node:10
-    depends_on: 
-      - integration
-    commands:
-      - npm run report-coverage
+      - docker-compose -f docker-compose.yml -f docker-compose.hw.yml down -v --rmi all || true
+      - if [ $RESULT -ne 0 ]; then exit 1; fi
 
   - name: deploy
     image: enigmampc/docker-client
     depends_on:
-      - coverage
+      - integration
     when:
       branch:
         - develop
@@ -94,9 +98,9 @@ steps:
     commands:
       - cd discovery-docker-network/enigma-p2p
       - echo $PASSWORD | docker login -u $USERNAME --password-stdin
-      - if [[ ${DRONE_BRANCH} == "master" ]]; then export TAG=latest; else export TAG=develop; fi
-      - docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$TAG --no-cache .
-      - docker push enigmampc/enigma_p2p:$TAG
+      - if [[ ${DRONE_BRANCH} == "master" ]]; then export DOCKER_TAG=latest; else export DOCKER_TAG=develop; fi
+      - docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$DOCKER_TAG --no-cache .
+      - docker push enigmampc/enigma_p2p:$DOCKER_TAG
 
 volumes:
   - name: sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,104 @@
+kind: pipeline
+name: default
+steps:
+
+  - name: p2p
+    image: node:10
+    commands:
+      - apt-get update && apt-get install build-essential
+      - npm install -g truffle@5.0.15
+      - npm install
+      - npm test
+      - if [ ${DRONE_BRANCH} == "develop" ] || [ ${TRAVIS_BRANCH} == "master" ]; then echo $DRONE_BRANCH ; npm run test-tree; fi
+
+  - name: integration
+    image: enigmampc/docker-client
+    privileged: true
+    depends_on: 
+      - p2p
+    volumes:
+      - name: sock
+        path: /var/run/docker.sock
+    commands:
+      - git clone https://github.com/enigmampc/discovery-docker-network.git
+      - cd discovery-docker-network && cp .env-template .env
+      - sed -i "s/COMPOSE_PROJECT_NAME=.*/COMPOSE_PROJECT_NAME=enigma_${DRONE_BUILD_NUMBER}/" .env
+      - export MATCHING_BRANCH_CONTRACT="$(git ls-remote --heads https://github.com/enigmampc/enigma-contract.git ${DRONE_BRANCH} | wc -l)"
+      - export MATCHING_BRANCH_CORE="$(git ls-remote --heads https://github.com/enigmampc/enigma-core.git ${DRONE_BRANCH} | wc -l)"
+      - |
+        if [[ "${DRONE_BRANCH}" == "master" ]]; then
+          export TAG=latest;
+          docker-compose pull
+        else
+          if [ $MATCHING_BRANCH_CONTRACT -eq 0 ] &&  [ $MATCHING_BRANCH_CORE -eq 0 ]; then
+            export TAG=develop;
+            sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=develop/" .env;
+            docker-compose pull
+          else
+            export TAG=${DRONE_BRANCH};
+            sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=${TAG}/" .env;
+            if [ $MATCHING_BRANCH_CONTRACT -eq 1 ] && [ $MATCHING_BRANCH_CORE -eq 0 ]; then
+              cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$TAG --no-cache . && cd ..
+              docker pull enigmampc/enigma_core_hw:develop
+              docker tag enigmampc/enigma_core_hw:develop enigmampc/enigma_core_hw:$TAG
+              docker pull enigmampc/enigma_km_hw:develop
+              docker tag enigmampc/enigma_km_hw:develop enigmampc/enigma_km_hw:$TAG
+            else
+              if [ $MATCHING_BRANCH_CONTRACT -eq 0 ] && [ $MATCHING_BRANCH_CORE -eq 1 ]; then
+                cd enigma-core
+                docker build --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$TAG --no-cache .
+                docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$TAG --no-cache .
+                cd ..
+                docker pull enigmampc/enigma_contract:develop
+                docker tag enigmampc/enigma_contract:develop enigmampc/enigma_contract:$TAG
+              else
+                cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$TAG --no-cache . && cd ..
+                cd enigma-core
+                docker build --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$TAG --no-cache .
+                docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$TAG --no-cache .
+                cd ..
+              fi
+            fi
+          fi
+        fi
+      - cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$TAG --no-cache . && cd ..
+      - export NODES=3
+      - docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client && export RESULT=$? || export RESULT=$?
+      - if [[ "${DRONE_BRANCH}" == "$TAG" ]]; then docker-compose down -v --rmi all; else docker-compose down -v; fi
+      - if [ $RESULT -ne 0 ]; exit 1; fi
+
+  - name: coverage
+    image: node:10
+    depends_on: 
+      - integration
+    commands:
+      - npm run report-coverage
+
+  - name: deploy
+    image: enigmampc/docker-client
+    depends_on:
+      - coverage
+    when:
+      branch:
+        - develop
+        - master
+    privileged: true
+    volumes:
+      - name: sock
+        path: /var/run/docker.sock
+    environment:
+      USERNAME:
+        from_secret: username
+      PASSWORD:
+        from_secret: password
+    commands:
+      - cd discovery-docker-network/enigma-p2p
+      - echo $PASSWORD | docker login -u $USERNAME --password-stdin
+      - if [[ ${DRONE_BRANCH} == "master" ]]; then export TAG=latest; else export TAG=develop; fi
+      - docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$TAG --no-cache .
+      - docker push enigmampc/enigma_p2p:$TAG
+
+volumes:
+  - name: sock
+    host:
+      path: /var/run/docker.sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -2,24 +2,9 @@ kind: pipeline
 name: default
 steps:
 
-  - name: p2p
-    image: node:10
-    environment:
-      CODECOV_TOKEN:
-        from_secret: CODECOV_TOKEN
-    commands:
-      - apt-get update && apt-get install build-essential
-      - npm install -g truffle@5.0.15
-      - npm install
-      - npm test
-      - if [[ "${DRONE_BRANCH}" == "develop" ]] || [[ "${DRONE_BRANCH}" == "master" ]]; then echo $DRONE_BRANCH ; npm run test-tree; fi
-      - npm run report-coverage
-
   - name: integration
     image: enigmampc/docker-client
     privileged: true
-    depends_on: 
-      - p2p
     volumes:
       - name: sock
         path: /var/run/docker.sock
@@ -27,51 +12,37 @@ steps:
       - git clone https://github.com/enigmampc/discovery-docker-network.git
       - cd discovery-docker-network && cp .env-template .env
       - sed -i "s/COMPOSE_PROJECT_NAME=.*/COMPOSE_PROJECT_NAME=enigma_${DRONE_BUILD_NUMBER}/" .env
-      - export MATCHING_BRANCH_CONTRACT="$(git ls-remote --heads https://github.com/enigmampc/enigma-contract.git ${DRONE_BRANCH} | wc -l)"
       - export MATCHING_BRANCH_CORE="$(git ls-remote --heads https://github.com/enigmampc/enigma-core.git ${DRONE_BRANCH} | wc -l)"
+      - export MATCHING_BRANCH_CONTRACT="$(git ls-remote --heads https://github.com/enigmampc/enigma-contract.git ${DRONE_BRANCH} | wc -l)"
       - export DOCKER_TAG=p2p_${DRONE_BUILD_NUMBER}
       - sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=${DOCKER_TAG}/" .env;
       - |
-        if [[ "${DRONE_BRANCH}" == "master" ]]; then
-          docker pull enigmampc/enigma_contract:latest
-          docker pull enigmampc/enigma_core_hw:latest
-          docker pull enigmampc/enigma_km_hw:latest
-          docker tag enigmampc/enigma_contract:latest enigmampc/enigma_contract:$DOCKER_TAG
-          docker tag enigmampc/enigma_core_hw:latest enigmampc/enigma_core_hw:$DOCKER_TAG
-          docker tag enigmampc/enigma_km_hw:latest enigmampc/enigma_km_hw:$DOCKER_TAG
-        else
-          if [ $MATCHING_BRANCH_CONTRACT -eq 0 ] && [ $MATCHING_BRANCH_CORE -eq 0 ]; then
-            docker pull enigmampc/enigma_contract:develop
-            docker pull enigmampc/enigma_core_hw:develop
-            docker pull enigmampc/enigma_km_hw:develop
-            docker tag enigmampc/enigma_contract:develop enigmampc/enigma_contract:$DOCKER_TAG
-            docker tag enigmampc/enigma_core_hw:develop enigmampc/enigma_core_hw:$DOCKER_TAG
-            docker tag enigmampc/enigma_km_hw:develop enigmampc/enigma_km_hw:$DOCKER_TAG
+        /bin/bash -c '
+        declare -a PROJECTS=(core km contract)
+        declare -A DOCKER_IMAGES=([core]=enigma_core_hw [km]=enigma_km_hw [contract]=enigma_contract)
+        declare -A GIT_BRANCH_ARG=([core]=GIT_BRANCH_CORE [km]=GIT_BRANCH_CORE [contract]=GIT_BRANCH_CONTRACT)
+        declare -A PROJECT_DIRECTORY=([core]=enigma-core [km]=enigma-core [contract]=enigma-contract)
+        declare -A PROJECT_BRANCH_FOUND=([core]=$MATCHING_BRANCH_CORE [km]=$MATCHING_BRANCH_CORE [contract]=$MATCHING_BRANCH_CONTRACT)
+        for project in $${PROJECTS[@]}; do
+          DOCKER_IMAGE="enigmampc/$${DOCKER_IMAGES[$project]}"
+          if [[ "$DRONE_BRANCH" == "master" ]]; then
+            docker pull "$DOCKER_IMAGE:latest"
+            docker tag "$DOCKER_IMAGE:latest" "$DOCKER_IMAGE:$DOCKER_TAG"
+          elif [ "$${PROJECT_BRANCH_FOUND[$project]}" -eq 0 ]; then
+            docker pull "$DOCKER_IMAGE:develop"
+            docker tag "$DOCKER_IMAGE:develop" "$DOCKER_IMAGE:$DOCKER_TAG"
           else
-            if [ $MATCHING_BRANCH_CONTRACT -eq 1 ] && [ $MATCHING_BRANCH_CORE -eq 0 ]; then
-              cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$DOCKER_TAG --no-cache . && cd ..
-              docker pull enigmampc/enigma_core_hw:develop
-              docker tag enigmampc/enigma_core_hw:develop enigmampc/enigma_core_hw:$DOCKER_TAG
-              docker pull enigmampc/enigma_km_hw:develop
-              docker tag enigmampc/enigma_km_hw:develop enigmampc/enigma_km_hw:$DOCKER_TAG
+            cd "$${PROJECT_DIRECTORY[$project]}"
+            if [[ "$project" == "km" ]]; then
+              docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t "$DOCKER_IMAGE:$DOCKER_TAG" --no-cache .
+            elif [[ "$project" == "core" ]]; then
+              docker build --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t "$DOCKER_IMAGE:$DOCKER_TAG" --no-cache .
             else
-              if [ $MATCHING_BRANCH_CONTRACT -eq 0 ] && [ $MATCHING_BRANCH_CORE -eq 1 ]; then
-                cd enigma-core
-                docker build --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$DOCKER_TAG --no-cache .
-                docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$DOCKER_TAG --no-cache .
-                cd ..
-                docker pull enigmampc/enigma_contract:develop
-                docker tag enigmampc/enigma_contract:develop enigmampc/enigma_contract:$DOCKER_TAG
-              else
-                cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$DOCKER_TAG --no-cache . && cd ..
-                cd enigma-core
-                docker build --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$DOCKER_TAG --no-cache .
-                docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=${DRONE_BRANCH} --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$DOCKER_TAG --no-cache .
-                cd ..
-              fi
+              docker build --build-arg "$${GIT_BRANCH_ARG[$project]}=${DRONE_BRANCH}" -t "$DOCKER_IMAGE:$DOCKER_TAG" --no-cache .
             fi
+            cd ..
           fi
-        fi
+        done'
       - cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$DOCKER_TAG --no-cache . && cd ..
       - export NODES=3
       - docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client && export RESULT=$? || export RESULT=$?

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,6 @@ language: node_js
 node_js:
   - "10.16"
 
-env:
-  - DOCKER_COMPOSE_VERSION=1.23.2
-
-before_install:
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
-
 install:
   - npm install -g truffle@5.0.15
   - npm install
@@ -21,18 +12,6 @@ script:
   - if [ ${TRAVIS_BRANCH} == "develop" ] || [ ${TRAVIS_BRANCH} == "master" ]; then
       echo $TRAVIS_BRANCH ; npm run test-tree;
     fi
-  - git clone https://github.com/enigmampc/discovery-docker-network.git
-  - if [[ $TRAVIS_BRANCH == "master" ]]; then export TAG=latest; else export TAG=develop; fi
-
-  - |
-    pushd discovery-docker-network &&
-    cp .env-template .env &&
-    sed -i "s/SGX_MODE=HW/SGX_MODE=SW/" .env &&
-    if [[ $TAG == "develop" ]]; then sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=develop/" .env; fi &&
-    sed -i "s/-vv/-v/" enigma-core/start_core.bash &&
-    popd
-  - pushd discovery-docker-network/enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=$TRAVIS_BRANCH -t enigmampc/enigma_p2p:$TAG --no-cache . >/dev/null && popd
-  - pushd discovery-docker-network && export NODES=3 && docker-compose -f docker-compose.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client && popd
 
 after_success:
   - npm run report-coverage
@@ -40,10 +19,3 @@ after_success:
 notifications:
   email:
     on_success: never
-
-deploy:
-  provider: script
-  script: bash scripts/deploy.sh
-  on:
-    all_branches: true
-    condition: $TRAVIS_BRANCH =~ ^master|develop$


### PR DESCRIPTION
The CI now checks for matching branches across the other two repos, and conditionally builds against those other branches if a match is found. The logic is as follows:

1. If branch equals `master`, then use `latest` docker images
2. Else, if feature branch does NOT have a match in other repos, then use `develop` docker images
3. Else, if there is a match in only one other repo, then build a local image using that remote branch, AND reuse the existing `develop` for the repo there is no match (by tagging it as the one that will be used)
4. Else (there is a match on both repos), then build both local images.

Because of concurrency challenges derived from the fact that now three different repos `core`, `p2p` and `contract` handle the CI builds in the same host and they share docker resources, the images need to be separated between builds to avoid cross-contamination if there is a bogus image. Thus all images are tagged with `repo_build`, and deleted at the end of the build.

Analogous to:
- enigmampc/enigma-core#232
- enigmampc/enigma-contract#159