### PR TITLE
BUG: fix deploy stage of .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -82,6 +82,7 @@ steps:
       PASSWORD:
         from_secret: password
     commands:
+      - cd docker-environment
       - echo $PASSWORD | docker login -u $USERNAME --password-stdin
       - if [[ ${DRONE_BRANCH} == "master" ]]; then export DOCKER_TAG=latest; else export DOCKER_TAG=develop; fi
       - make clone-core BRANCH=${DRONE_BRANCH}
@@ -89,10 +90,10 @@ steps:
       - make clone-km BRANCH=${DRONE_BRANCH}
       - make build-km SGX_MODE=SW DOCKER_TAG=$DOCKER_TAG
       - make build-worker SGX_MODE=SW DOCKER_TAG=$DOCKER_TAG
+      - make build-km DOCKER_TAG=$DOCKER_TAG
+      - make build-worker DOCKER_TAG=$DOCKER_TAG
       - docker push enigmampc/worker_sw:$DOCKER_TAG
       - docker push enigmampc/key_management_sw:$DOCKER_TAG
-      - docker tag enigmampc/worker_hw:p2p_${DRONE_BUILD_NUMBER} enigmampc/worker_hw:$DOCKER_TAG
-      - docker tag enigmampc/key_management_hw:p2p_${DRONE_BUILD_NUMBER} enigmampc/key_management_hw:$DOCKER_TAG
       - docker push enigmampc/worker_hw:$DOCKER_TAG
       - docker push enigmampc/key_management_hw:$DOCKER_TAG
 


### PR DESCRIPTION
At the deploy stage, the docker images used for testing are no longer available; so we build them again to be pushed to the DockerHub

And we `cd` into the folder because when a new step in the pipeline starts, we start at the root